### PR TITLE
docs: replace deprecated add-skill install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Archive, export, and notarize macOS apps with Developer ID signing.
 Install this skill pack:
 
 ```bash
-npx add-skill rudrankriyam/app-store-connect-cli-skills
+npx skills add rudrankriyam/app-store-connect-cli-skills
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- Replace deprecated `npx add-skill` in `README.md` with `npx skills add`.
- Align installation instructions with the current CLI rename/deprecation behavior.
- Confirm no other Markdown docs in this repo still reference `add-skill`.

## Test plan
- [x] Run `npx add-skill --help` and verify deprecation output points to `npx skills add`.
- [x] Search Markdown docs for `add-skill` and confirm there are no remaining matches.