### PR TITLE
docs(skills): use asc cli wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# App Store Connect CLI Skills
+# asc cli skills
 
-A collection of Agent Skills for shipping with the [App Store Connect CLI](https://github.com/rudrankriyam/App-Store-Connect-CLI) (`asc`). These skills are designed for zero-friction automation around builds, TestFlight, metadata, submissions, and signing.
+A collection of Agent Skills for shipping with the [asc cli](https://github.com/rudrankriyam/App-Store-Connect-CLI) (`asc`). These skills are designed for zero-friction automation around builds, TestFlight, metadata, submissions, and signing.
+
+This is a community-maintained, unofficial skill pack and is not affiliated with Apple.
 
 Skills follow the Agent Skills format.
 

--- a/skills/asc-app-create-ui/SKILL.md
+++ b/skills/asc-app-create-ui/SKILL.md
@@ -3,7 +3,7 @@ name: asc-app-create-ui
 description: Create a new App Store Connect app record via browser automation. Use when there is no public API for app creation and you need an agent to drive the New App form.
 ---
 
-# ASC App Create (UI Automation)
+# asc app create (UI automation)
 
 Use this skill to create a new App Store Connect app by driving the web UI.
 This is opt-in, local-only automation that requires the user to be signed in.

--- a/skills/asc-build-lifecycle/SKILL.md
+++ b/skills/asc-build-lifecycle/SKILL.md
@@ -3,7 +3,7 @@ name: asc-build-lifecycle
 description: Track build processing, find latest builds, and clean up old builds with asc. Use when managing build retention or waiting on processing.
 ---
 
-# ASC Build Lifecycle
+# asc build lifecycle
 
 Use this skill to manage build state, processing, and retention.
 

--- a/skills/asc-cli-usage/SKILL.md
+++ b/skills/asc-cli-usage/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: asc-cli-usage
-description: Guidance for using the App Store Connect CLI in this repo (flags, output formats, pagination, auth, and discovery). Use when asked to run or design asc commands or interact with App Store Connect via the CLI.
+description: Guidance for using asc cli in this repo (flags, output formats, pagination, auth, and discovery). Use when asked to run or design asc commands or interact with App Store Connect via the CLI.
 ---
 
-# ASC CLI usage
+# asc cli usage
 
 Use this skill when you need to run or design `asc` commands for App Store Connect.
 

--- a/skills/asc-id-resolver/SKILL.md
+++ b/skills/asc-id-resolver/SKILL.md
@@ -3,7 +3,7 @@ name: asc-id-resolver
 description: Resolve App Store Connect IDs (apps, builds, versions, groups, testers) from human-friendly names using asc. Use when commands require IDs.
 ---
 
-# ASC ID Resolver
+# asc id resolver
 
 Use this skill to map names to IDs needed by other commands.
 

--- a/skills/asc-metadata-sync/SKILL.md
+++ b/skills/asc-metadata-sync/SKILL.md
@@ -3,7 +3,7 @@ name: asc-metadata-sync
 description: Sync and validate App Store metadata and localizations with asc, including legacy metadata format migration. Use when updating metadata or translations.
 ---
 
-# ASC Metadata Sync
+# asc metadata sync
 
 Use this skill to keep local metadata in sync with App Store Connect.
 

--- a/skills/asc-shots-pipeline/SKILL.md
+++ b/skills/asc-shots-pipeline/SKILL.md
@@ -3,14 +3,14 @@ name: asc-shots-pipeline
 description: Orchestrate iOS screenshot automation with xcodebuild/simctl for build-run, AXe for UI actions, JSON settings and plan files, Go-based framing (`asc screenshots frame`), and screenshot upload (`asc screenshots upload`). Use when users ask for automated screenshot capture, AXe-driven simulator flows, frame composition, or screenshot-to-upload pipelines.
 ---
 
-# ASC screenshots pipeline (xcodebuild -> AXe -> frame -> asc)
+# asc screenshots pipeline (xcodebuild -> AXe -> frame -> asc)
 
 Use this skill for agent-driven screenshot workflows where the app is built and launched with Xcode CLI tools, UI is driven with AXe, and screenshots are uploaded with `asc`.
 
 ## Current scope
 - Implemented now: build/run, AXe plan capture, frame composition, and upload.
 - Device discovery is built-in via `asc screenshots list-frame-devices`.
-- Local screenshot automation commands are experimental in ASC.
+- Local screenshot automation commands are experimental in asc cli.
 - Framing is pinned to Koubou `0.13.0` for deterministic output.
 - Feedback/issues: https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/new/choose
 
@@ -113,7 +113,7 @@ Minimal `.asc/screenshots.json` example:
 
 ## 4) Frame screenshots with `asc screenshots frame`
 
-ASC pins framing to Koubou `0.13.0`.
+asc cli pins framing to Koubou `0.13.0`.
 Install and verify before running framing steps:
 
 ```bash

--- a/skills/asc-signing-setup/SKILL.md
+++ b/skills/asc-signing-setup/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: asc-signing-setup
-description: Set up bundle IDs, capabilities, signing certificates, and provisioning profiles with the asc CLI. Use when onboarding a new app or rotating signing assets.
+description: Set up bundle IDs, capabilities, signing certificates, and provisioning profiles with the asc cli. Use when onboarding a new app or rotating signing assets.
 ---
 
-# ASC Signing Setup
+# asc signing setup
 
 Use this skill when you need to create or renew signing assets for iOS/macOS apps.
 

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -3,7 +3,7 @@ name: asc-submission-health
 description: Preflight App Store submissions, submit builds, and monitor review status with asc. Use when shipping or troubleshooting review submissions.
 ---
 
-# ASC Submission Health
+# asc submission health
 
 Use this skill to reduce review submission failures and monitor status.
 

--- a/skills/asc-subscription-localization/SKILL.md
+++ b/skills/asc-subscription-localization/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: asc-subscription-localization
-description: Bulk-localize subscription and in-app purchase display names across all App Store locales using asc. Use when you want to fill in subscription/IAP names for every language without clicking through ASC manually.
+description: Bulk-localize subscription and in-app purchase display names across all App Store locales using asc. Use when you want to fill in subscription/IAP names for every language without clicking through App Store Connect manually.
 ---
 
-# ASC Subscription Localization
+# asc subscription localization
 
 Use this skill to bulk-create or bulk-update display names (and descriptions) for subscriptions, subscription groups, and in-app purchases across all App Store Connect locales. This eliminates the tedious manual process of clicking through each language in App Store Connect to set the same display name.
 

--- a/skills/asc-testflight-orchestration/SKILL.md
+++ b/skills/asc-testflight-orchestration/SKILL.md
@@ -3,7 +3,7 @@ name: asc-testflight-orchestration
 description: Orchestrate TestFlight distribution, groups, testers, and What to Test notes using asc. Use when rolling out betas.
 ---
 
-# ASC TestFlight Orchestration
+# asc TestFlight orchestration
 
 Use this skill when managing TestFlight testers, groups, and build distribution.
 

--- a/skills/asc-workflow/SKILL.md
+++ b/skills/asc-workflow/SKILL.md
@@ -3,7 +3,7 @@ name: asc-workflow
 description: Define, validate, and run lane-style multi-step automation sequences using `asc workflow` and a repo-local `.asc/workflow.json`. Use when migrating from lane-based automation, building enterprise CI flows, or orchestrating multi-command `asc` runs.
 ---
 
-# ASC Workflows (lane-style automation)
+# asc workflows (lane-style automation)
 
 Use this skill when you need to create or run `.asc/workflow.json` workflows via:
 - `asc workflow run`


### PR DESCRIPTION
## Summary

Aligns this skill pack's wording with the main asc cli repo branding:
- Use `asc cli` (lowercase) consistently
- Avoid `App Store Connect CLI` phrasing that can read as official
- Add a short unofficial/not affiliated note

## Changes
- `README.md`: rename heading to `asc cli skills` and add unofficial note
- Skill docs: update titles and descriptions (e.g. `ASC ...` -> `asc ...`)

## Notes
- This does not rename any skill IDs or directories (only wording).