### PR TITLE
docs(asc-workflow): improve workflow feature coverage and CI guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ Guidance for running `asc` commands (flags, pagination, output, auth).
 
 ### asc-workflow
 
-Define and run lane-style workflows using `asc workflow` and `.asc/workflow.json`.
+Define and run repo-local automation graphs using `asc workflow` and `.asc/workflow.json`.
 
 **Use when:**
 - You are migrating from lane-based automation to repo-local workflows
-- You want multi-step orchestration with JSON-only stdout for CI and agents
-- You need hooks (`before_all`, `after_all`, `error`), conditionals (`if`), and sub-workflows
+- You need multi-step orchestration with machine-parseable JSON output for CI/agents
+- You need hooks (`before_all`, `after_all`, `error`), conditionals (`if`), and private helper sub-workflows
+- You want validation (`asc workflow validate`) with cycle/reference checks before execution
 
 ### asc-app-create-ui
 

--- a/skills/asc-workflow/SKILL.md
+++ b/skills/asc-workflow/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: asc-workflow
-description: Define, validate, and run lane-style multi-step automation sequences using `asc workflow` and a repo-local `.asc/workflow.json`. Use when migrating from lane-based automation, building enterprise CI flows, or orchestrating multi-command `asc` runs.
+description: Define, validate, and run repo-local multi-step automations with `asc workflow` and `.asc/workflow.json`. Use when migrating from lane tools, wiring CI pipelines, or orchestrating repeatable `asc` + shell release flows with hooks, conditionals, and sub-workflows.
 ---
 
-# asc workflows (lane-style automation)
+# asc workflow
 
-Use this skill when you need to create or run `.asc/workflow.json` workflows via:
+Use this skill when you need lane-style automation inside the CLI using:
 - `asc workflow run`
 - `asc workflow validate`
 - `asc workflow list`
 
-Workflows are a lane-style "lanes" replacement: named, multi-step automation sequences that compose existing `asc` commands and normal shell commands.
+This feature is best for deterministic automation that lives in your repo, is reviewable in PRs, and can run the same way locally and in CI.
 
 ## Command discovery
 
@@ -20,77 +20,139 @@ Workflows are a lane-style "lanes" replacement: named, multi-step automation seq
   - `asc workflow validate --help`
   - `asc workflow list --help`
 
-## Key commands (typical flow)
+## End-to-end flow
 
-1. Validate the workflow file (CI gate):
+1. Author `.asc/workflow.json`
+2. Validate structure and references:
    - `asc workflow validate`
-2. Dry-run a workflow (no side effects):
-   - `asc workflow run --dry-run beta`
-3. Run the workflow with runtime parameters:
-   - `asc workflow run beta BUILD_ID:123456789 GROUP_ID:abcdef`
-4. List available workflows (for discovery):
+3. Discover available workflows:
    - `asc workflow list`
-   - Include private workflows: `asc workflow list --all`
+   - `asc workflow list --all` (includes private helpers)
+4. Preview execution without side effects:
+   - `asc workflow run --dry-run beta`
+5. Execute with runtime params:
+   - `asc workflow run beta BUILD_ID:123456789 GROUP_ID:abcdef`
 
 ## File location and format
 
-- Default file path: `.asc/workflow.json` (repo-local; commit it with your code).
-- The workflow file supports JSONC comments (`//` and `/* */`).
+- Default path: `.asc/workflow.json`
+- Override path: `asc workflow run --file ./path/to/workflow.json <name>`
+- JSONC comments are supported (`//` and `/* ... */`)
 
-## Output contract (agent-friendly)
+## Output and CI contract
 
-- stdout: JSON-only (structured result)
-- stderr: step/hook command output and dry-run previews
+- `stdout`: structured JSON result (`status`, `steps`, durations)
+- `stderr`: step command output, hook output, dry-run previews
+- `asc workflow validate` always prints JSON and returns non-zero when invalid
 
-This makes it safe to do:
+This enables machine-safe checks:
 
 ```bash
+asc workflow validate | jq -e '.valid == true'
 asc workflow run beta BUILD_ID:123 GROUP_ID:xyz | jq -e '.status == "ok"'
 ```
 
-## Runtime params (KEY:VALUE / KEY=VALUE)
+## Schema (what the feature supports)
+
+Top-level keys:
+- `env`: global defaults
+- `before_all`: command run once before steps
+- `after_all`: command run once after successful steps
+- `error`: command run when any failure occurs
+- `workflows`: named workflow map
+
+Workflow keys:
+- `description`
+- `private` (not directly runnable)
+- `env`
+- `steps`
+
+Step forms:
+- String shorthand: `"echo hello"` -> run step
+- Object with:
+  - `run`: shell command
+  - `workflow`: call sub-workflow
+  - `name`: label for reporting
+  - `if`: conditional var name
+  - `with`: env overrides for workflow-call steps only
+
+## Runtime params (`KEY:VALUE` / `KEY=VALUE`)
 
 - `asc workflow run <name> [KEY:VALUE ...]` supports both separators:
   - `VERSION:2.1.0`
   - `VERSION=2.1.0`
-- In steps, reference params via `$VAR` (shell expansion).
+- If both separators exist, the first one wins.
+- Repeated keys are last-write-wins.
+- In step commands, reference params via shell expansion (`$VAR`).
 - Avoid putting secrets in `.asc/workflow.json`; pass them via CI secrets/env.
 
-## Hooks
+## Run-tail flags
 
-Workflows support definition-level hooks:
-- `before_all`: runs once before any steps
-- `after_all`: runs once after all steps (only if steps succeeded)
-- `error`: runs on any failure
+`asc workflow run` also accepts core flags after the workflow name:
+- `--dry-run`
+- `--pretty`
+- `--file`
 
-When hook output matters, keep hooks simple and write their logs to stderr.
+Examples:
+- `asc workflow run beta --dry-run`
+- `asc workflow run beta --file .asc/workflow.json BUILD_ID:123`
 
-## Conditionals (`if`)
+## Execution semantics
 
-- Add `"if": "VAR_NAME"` to a step to skip it when `VAR_NAME` is falsy.
-- The conditional checks workflow env/params first, and then falls back to `os.Getenv(VAR_NAME)`.
-- Truthy values: `1`, `true`, `yes`, `y`, `on` (case-insensitive).
+- `before_all` runs once before step execution
+- `after_all` runs only when steps succeed
+- `error` runs on failure (step failure, before/after hook failure)
+- Sub-workflows are executed inline as part of the call step
+- Maximum sub-workflow nesting depth is 16
+
+## Env precedence
+
+Main workflow run:
+- `definition.env` < `workflow.env` < CLI params
+
+Sub-workflow call step (`"workflow": "...", "with": {...}`):
+- sub-workflow `env` defaults
+- caller env (including CLI params) overrides
+- step `with` overrides all
 
 ## Sub-workflows and private workflows
 
-- A step can call another workflow via `"workflow": "<name>"`.
-- `"with"` env overrides are only valid on workflow steps (not run steps).
-- `"private": true` workflows:
-  - cannot be run directly from the CLI
-  - can be called by other workflows as sub-workflows
+- Use `"workflow": "<name>"` to call helper workflows.
+- Use `"private": true` for helper-only workflows.
+- Private workflows:
+  - cannot be run directly
+  - can be called by other workflows
   - are hidden from `asc workflow list` unless `--all` is used
+- Validation catches unknown workflow references and cyclic references.
 
-## Recommended authoring approach (enterprise-friendly)
+## Conditionals (`if`)
 
-- Keep steps deterministic and explicit (prefer IDs where possible).
-- Validate early (`asc workflow validate`) and keep the file in version control.
-- Start with `--dry-run` before enabling real runs in CI.
-- Use existing `asc` commands for the actual work (build upload, TestFlight distribution, submission).
-- Use `--confirm` on destructive operations inside steps; workflows should never add interactive prompts.
+- Add `"if": "VAR_NAME"` on a step.
+- Step runs only if `VAR_NAME` is truthy.
+- Truthy: `1`, `true`, `yes`, `y`, `on` (case-insensitive).
+- Resolution order for `if` lookup:
+  1. merged workflow env/params
+  2. `os.Getenv(VAR_NAME)`
 
-## Example `.asc/workflow.json` template
+## Dry-run behavior
 
-This is a practical starting point for lane migration; adapt step commands to your org.
+- `asc workflow run --dry-run <name>` does not execute commands.
+- It prints previews to `stderr`.
+- Dry-run shows raw commands (without env expansion), which helps avoid secret leakage in previews.
+
+## Shell behavior
+
+- Run steps use `bash -o pipefail -c` when bash is available.
+- Fallback is `sh -c` when bash is unavailable.
+- Pipelines therefore fail correctly in most CI shells when bash exists.
+
+## Practical authoring rules
+
+- Keep workflow files in version control.
+- Use IDs in step commands where possible for deterministic automation.
+- Use `--confirm` for destructive `asc` operations inside steps.
+- Validate first, then dry-run, then real run.
+- Keep hooks lightweight and side-effect aware.
 
 ```json
 {
@@ -103,7 +165,7 @@ This is a practical starting point for lane migration; adapt step commands to yo
   "error": "echo workflow_failed",
   "workflows": {
     "beta": {
-      "description": "Distribute a build to a TestFlight group",
+      "description": "Distribute a build to a TestFlight group and notify",
       "env": {
         "GROUP_ID": ""
       },
@@ -120,6 +182,11 @@ This is a practical starting point for lane migration; adapt step commands to yo
           "name": "add_build_to_group",
           "if": "BUILD_ID",
           "run": "asc builds add-groups --build $BUILD_ID --group $GROUP_ID"
+        },
+        {
+          "name": "notify",
+          "if": "SLACK_WEBHOOK",
+          "run": "echo sent_release_notice"
         }
       ]
     },
@@ -152,3 +219,21 @@ This is a practical starting point for lane migration; adapt step commands to yo
 }
 ```
 
+## Useful invocations
+
+```bash
+# Validate and fail CI on invalid file
+asc workflow validate | jq -e '.valid == true'
+
+# Show discoverable workflows
+asc workflow list --pretty
+
+# Include private helpers
+asc workflow list --all --pretty
+
+# Preview a real run
+asc workflow run --dry-run beta BUILD_ID:123 GROUP_ID:grp_abc
+
+# Run with params and assert success
+asc workflow run beta BUILD_ID:123 GROUP_ID:grp_abc | jq -e '.status == "ok"'
+```


### PR DESCRIPTION
## Summary
This PR improves the `asc-workflow` skill so it accurately reflects real `asc workflow` behavior and better showcases the feature for CI/automation users.

## What changed
- Reworked `skills/asc-workflow/SKILL.md` to document:
  - execution semantics for hooks and failures (`before_all`, `after_all`, `error`)
  - env precedence and `with` override behavior for sub-workflows
  - private/sub-workflow behavior and listing visibility (`--all`)
  - validation behavior (references/cycles, invalid config handling)
  - dry-run behavior and safety characteristics
  - shell execution behavior (`bash -o pipefail` fallback)
  - CI-ready command patterns using JSON contracts
  - run-tail flag support for `workflow run` (`--dry-run`, `--pretty`, `--file` after workflow name)
- Updated skills index wording in `README.md` to better describe the workflow capability.

## Why
The existing skill guidance was under-informing users about important runtime semantics and CI usage patterns, making the feature appear narrower than it is.

Closes #13
