### PR TITLE
Add Google Play Developer CLI (gpd) skills

### DIFF
--- a/gpd-cli-usage/SKILL.md
+++ b/gpd-cli-usage/SKILL.md
@@ -16,7 +16,7 @@ Use this skill when you need to run or design `gpd` commands for Google Play Dev
 ## Flag conventions
 - Use explicit long flags (for example: `--package`, `--track`, `--status`).
 - No interactive prompts; destructive operations require `--confirm`.
-- Use `--paginate` when the user wants all pages.
+- Use `--all` when the user wants all pages.
 
 ## Output formats
 - Default output is minified JSON.

--- a/gpd-id-resolver/SKILL.md
+++ b/gpd-id-resolver/SKILL.md
@@ -45,4 +45,4 @@ Use this skill to map names to IDs needed by other gpd commands.
 
 ## Output tips
 - JSON is default; use `--pretty` for debugging.
-- Use `--paginate` on list commands to avoid missing items.
+- Use `--all` on list commands to avoid missing items.

--- a/gpd-ppp-pricing/SKILL.md
+++ b/gpd-ppp-pricing/SKILL.md
@@ -27,13 +27,20 @@ gpd monetization baseplans batch-migrate-prices --package com.example.app sub123
 Example `migrate.json`:
 ```json
 {
-  "basePlans": [
+  "requests": [
     {
       "basePlanId": "plan456",
-      "regionCode": "US",
-      "priceMicros": 9990000
+      "regionalPriceMigrations": [
+        {
+          "regionCode": "US",
+          "priceMicros": 9990000
+        }
+      ]
     }
-  ]
+  ],
+  "regionsVersion": {
+    "version": "2024-01-01"
+  }
 }
 ```
 

--- a/gpd-release-flow/SKILL.md
+++ b/gpd-release-flow/SKILL.md
@@ -30,7 +30,7 @@ Use when you need precise control or multiple changes in one commit.
 
 ```bash
 # 1. Create edit
-EDIT_ID=$(gpd publish edit create --package com.example.app | jq -r '.id')
+EDIT_ID=$(gpd publish edit create --package com.example.app | jq -r '.data.editId')
 
 # 2. Upload build without auto-commit
 gpd publish upload app.aab --package com.example.app --edit-id $EDIT_ID --no-auto-commit


### PR DESCRIPTION
## Summary

This PR adds comprehensive Agent Skills for the Google Play Developer CLI (gpd), the Android equivalent to the App Store Connect CLI.

## New Skills Added

- **gpd-cli**: Main entry point for Google Play Developer Console automation
- **gpd-cli-usage**: Command discovery, flags, auth, and output conventions
- **gpd-release-flow**: End-to-end track releases, rollouts, and edit lifecycle
- **gpd-betagroups**: Beta testing groups and distribution
- **gpd-build-lifecycle**: Build processing and release state
- **gpd-submission-health**: Preflight checks and validation
- **gpd-metadata-sync**: Listings, assets, and Fastlane metadata sync
- **gpd-ppp-pricing**: Territory-specific pricing (PPP) workflows
- **gpd-id-resolver**: Package, track, and monetization ID resolution

## Key Features

- JSON-first output (consistent with asc CLI)
- Service account authentication support
- Track management (internal, alpha, beta, production)
- Staged rollouts
- Edit lifecycle for atomic operations
- Beta group orchestration
- Metadata sync (including Fastlane migration)

## Usage Examples

- Upload Android app to Google Play internal testing
- Release version to production with staged rollout
- Promote beta build to production
- Sync Fastlane metadata to Google Play Store listing

## Related

- Google Play Developer CLI: https://github.com/dl-alexandre/Google-Play-Developer-CLI
- Complements existing asc skills for cross-platform app publishing

---

This is a community contribution to extend the skill pack beyond iOS/macOS to Android development workflows.
