### PR TITLE
Add Google Play Developer CLI (gpd) skills with audit fixes

### DIFF
--- a/skills/gpd-betagroups/SKILL.md
+++ b/skills/gpd-betagroups/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: gpd-betagroups
+description: Orchestrate Google Play beta testing groups and distribution using gpd. Use when managing testers, internal testing, or beta rollouts.
+---
+
+# GPD Beta Groups
+
+Use this skill when managing beta testers, groups, and build distribution on Google Play.
+
+## List and manage testers
+```bash
+gpd publish testers list --package com.example.app --track internal
+gpd publish testers list --package com.example.app --track beta
+gpd publish testers add --package com.example.app --track internal --group testers@example.com
+```
+
+## Distribute builds to testing tracks
+```bash
+gpd publish release --package com.example.app --track internal --status completed
+gpd publish release --package com.example.app --track beta --status completed
+```
+
+## Promote between testing tracks
+```bash
+gpd publish promote --package com.example.app --from-track internal --to-track beta
+gpd publish promote --package com.example.app --from-track beta --to-track production
+```
+
+## Notes
+- Use `--track internal` for fast internal distribution.
+- Prefer IDs for deterministic operations; use the ID resolver skill when needed.

--- a/skills/gpd-build-lifecycle/SKILL.md
+++ b/skills/gpd-build-lifecycle/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: gpd-build-lifecycle
+description: Track build processing, status, and retention for Google Play using gpd publish commands. Use when waiting on processing or managing releases.
+---
+
+# GPD Build Lifecycle
+
+Use this skill to manage build state, processing, and retention.
+
+## Upload and validate
+```bash
+gpd publish upload app.aab --package com.example.app
+```
+
+## Inspect release status
+```bash
+gpd publish status --package com.example.app --track internal
+gpd publish status --package com.example.app --track production
+```
+
+## Recent tracks and releases
+```bash
+gpd publish tracks --package com.example.app
+```
+
+## Internal app sharing
+Use for fast distribution of a build without a full track release.
+
+```bash
+gpd publish internal-share upload app.aab --package com.example.app
+```
+
+## Cleanup and rollback
+```bash
+gpd publish halt --package com.example.app --track production --confirm
+gpd publish rollback --package com.example.app --track production --confirm
+```
+
+## Notes
+- Prefer `gpd publish release` for end-to-end flow instead of manual steps.
+- Use a new version code for each uploaded build.

--- a/skills/gpd-cli-usage/SKILL.md
+++ b/skills/gpd-cli-usage/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: gpd-cli-usage
+description: Guidance for using the Google Play Developer CLI (flags, output formats, auth, pagination). Use when asked to run or design gpd commands for Play Console workflows.
+---
+
+# GPD CLI usage
+
+Use this skill when you need to run or design `gpd` commands for Google Play Developer Console.
+
+## Command discovery
+- Always use `--help` to confirm commands and flags.
+  - `gpd --help`
+  - `gpd publish --help`
+  - `gpd monetization --help`
+
+## Flag conventions
+- Use explicit long flags (for example: `--package`, `--track`, `--status`).
+- No interactive prompts; destructive operations require `--confirm`.
+- Use `--all` when the user wants all pages.
+
+## Output formats
+- Default output is minified JSON.
+- Use `--pretty` for readable JSON during debugging.
+
+## Authentication and defaults
+- Service account auth via `GPD_SERVICE_ACCOUNT_KEY` is required.
+- Validate access for a package:
+  - `gpd auth check --package com.example.app`
+
+## Safety
+- Use `--dry-run` when available before destructive operations.
+- Prefer edit lifecycle (`gpd publish edit create`) for multi-step publishing.

--- a/skills/gpd-cli/SKILL.md
+++ b/skills/gpd-cli/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: gpd-cli
+description: Manage Google Play Developer Console using the gpd CLI. Use when working with Android app publishing, Play Store releases, app reviews, Android vitals, in-app purchases, subscriptions, or when the user mentions Google Play, Play Store, Android publishing, or gpd.
+---
+
+# Google Play Developer CLI
+
+Manage Google Play Developer Console using the `gpd` command-line tool.
+
+## Related Skills
+
+- `gpd-cli-usage`: command discovery, flags, auth, and output conventions
+- `gpd-release-flow`: end-to-end track releases and rollouts
+- `gpd-submission-health`: preflight checks and validation
+- `gpd-metadata-sync`: listings, assets, and Fastlane metadata
+- `gpd-ppp-pricing`: regional pricing workflows
+- `gpd-build-lifecycle`: build processing and release state
+- `gpd-betagroups`: beta testers and distribution
+- `gpd-id-resolver`: resolve package, track, and monetization IDs
+
+## Prerequisites
+
+```bash
+gpd --version
+
+export GPD_SERVICE_ACCOUNT_KEY='{"type": "service_account", ...}'
+gpd auth status
+gpd auth check --package com.example.app
+```
+
+## CLI Usage
+
+- Use `gpd --help` and `gpd <area> --help` to confirm commands and flags.
+- Default output is minified JSON; use `--pretty` when you need readable output.
+- Use `--dry-run` when available before destructive operations.
+- Destructive actions require `--confirm` (for example: halt, rollback, delete).
+
+## Publishing
+
+### Upload & Release
+
+```bash
+gpd publish upload app.aab --package com.example.app
+gpd publish release --package com.example.app --track internal --status draft
+gpd publish release --package com.example.app --track production --status inProgress --version-code 123
+gpd publish status --package com.example.app --track production
+gpd publish tracks --package com.example.app
+```
+
+### Rollouts
+
+```bash
+gpd publish rollout --package com.example.app --track production --percentage 10
+gpd publish promote --package com.example.app --from-track beta --to-track production
+gpd publish halt --package com.example.app --track production --confirm
+gpd publish rollback --package com.example.app --track production --confirm
+```
+
+### Edit Lifecycle
+
+```bash
+gpd publish edit create --package com.example.app
+gpd publish edit list --package com.example.app
+gpd publish edit validate EDIT_ID --package com.example.app
+gpd publish edit commit EDIT_ID --package com.example.app
+gpd publish edit delete EDIT_ID --package com.example.app
+gpd publish upload app.aab --package com.example.app --edit-id EDIT_ID --no-auto-commit
+```
+
+### Store Listing
+
+```bash
+gpd publish listing get --package com.example.app
+gpd publish listing update --package com.example.app --locale en-US --title "My App"
+gpd publish details get --package com.example.app
+gpd publish details update --package com.example.app --contact-email support@example.com
+```
+
+### Images
+
+```bash
+gpd publish images list phoneScreenshots --package com.example.app --locale en-US
+gpd publish images upload icon icon.png --package com.example.app --locale en-US
+gpd publish images delete phoneScreenshots IMAGE_ID --package com.example.app --locale en-US
+gpd publish images deleteall featureGraphic --package com.example.app --locale en-US
+gpd publish assets upload ./assets --package com.example.app
+gpd publish assets spec
+gpd publish deobfuscation upload mapping.txt --package com.example.app --type proguard --version-code 123
+gpd publish internal-share upload app.aab --package com.example.app
+```
+
+### Testers
+
+```bash
+gpd publish testers list --package com.example.app --track internal
+gpd publish testers add --package com.example.app --track internal --group testers@example.com
+```
+
+## Reviews
+
+```bash
+gpd reviews list --package com.example.app --min-rating 1 --max-rating 3
+gpd reviews list --package com.example.app --include-review-text --scan-limit 200
+gpd reviews reply --package com.example.app --review-id REVIEW_ID --text "Thank you!"
+```
+
+## Android Vitals
+
+```bash
+gpd vitals crashes --package com.example.app --start-date 2024-01-01 --end-date 2024-01-31
+gpd vitals anrs --package com.example.app --start-date 2024-01-01 --end-date 2024-01-31
+gpd vitals excessive-wakeups --package com.example.app --start-date 2024-01-01 --end-date 2024-01-31
+gpd vitals slow-rendering --package com.example.app --start-date 2024-01-01 --end-date 2024-01-31
+gpd vitals slow-start --package com.example.app --start-date 2024-01-01 --end-date 2024-01-31
+gpd vitals errors issues search --package com.example.app --query "NullPointerException" --interval last30Days
+gpd vitals errors reports search --package com.example.app --query "crash" --interval last7Days --deobfuscate
+gpd vitals errors counts get --package com.example.app
+gpd vitals errors counts query --package com.example.app --start-date 2024-01-01 --end-date 2024-01-31
+gpd vitals anomalies list --package com.example.app --metric crashRate --time-period last30Days
+```
+
+## Monetization
+
+### Products
+
+```bash
+gpd monetization products list --package com.example.app
+gpd monetization products get sku123 --package com.example.app
+gpd monetization products create --package com.example.app --product-id sku123 --type managed --default-price 990000
+gpd monetization products update --package com.example.app sku123 --status inactive
+gpd monetization products delete --package com.example.app sku123
+gpd monetization onetimeproducts list --package com.example.app
+gpd monetization onetimeproducts get sku123 --package com.example.app
+gpd monetization onetimeproducts create --package com.example.app --product-id sku123 --type consumable
+gpd monetization onetimeproducts update --package com.example.app sku123 --default-price 1990000
+gpd monetization onetimeproducts delete --package com.example.app sku123
+```
+
+### Subscriptions
+
+```bash
+gpd monetization subscriptions list --package com.example.app
+gpd monetization subscriptions get sub123 --package com.example.app
+gpd monetization subscriptions create --package com.example.app --product-id sub123 --file subscription.json
+gpd monetization subscriptions update --package com.example.app sub123 --file subscription.json
+gpd monetization subscriptions patch --package com.example.app sub123 --file subscription.json --update-mask basePlans
+gpd monetization subscriptions delete --package com.example.app sub123 --confirm
+gpd monetization subscriptions archive --package com.example.app sub123
+gpd monetization subscriptions batchGet --package com.example.app --ids sub1,sub2,sub3
+gpd monetization subscriptions batchUpdate --package com.example.app --file batch-update.json
+```
+
+### Base Plans & Offers
+
+```bash
+gpd monetization baseplans activate --package com.example.app sub123 plan456
+gpd monetization baseplans deactivate --package com.example.app sub123 plan456
+gpd monetization baseplans delete --package com.example.app sub123 plan456 --confirm
+gpd monetization baseplans migrate-prices --package com.example.app sub123 plan456 --region-code US --price-micros 999000
+gpd monetization baseplans batch-migrate-prices --package com.example.app sub123 --file migrate.json
+gpd monetization baseplans batch-update-states --package com.example.app sub123 --file states.json
+gpd monetization offers list --package com.example.app sub123 plan456
+gpd monetization offers create --package com.example.app sub123 plan456 --offer-id offer789 --file offer.json
+gpd monetization offers get --package com.example.app sub123 plan456 offer789
+gpd monetization offers delete --package com.example.app sub123 plan456 offer789 --confirm
+gpd monetization offers activate --package com.example.app sub123 plan456 offer789
+gpd monetization offers deactivate --package com.example.app sub123 plan456 offer789
+gpd monetization offers batchGet --package com.example.app sub123 plan456 --offer-ids offer1,offer2
+gpd monetization offers batchUpdate --package com.example.app sub123 plan456 --file offers.json
+gpd monetization offers batchUpdateStates --package com.example.app sub123 plan456 --file states.json
+```
+
+## Purchases
+
+```bash
+gpd purchases verify --package com.example.app --token TOKEN --product-id sku123
+gpd purchases voided list --package com.example.app --start-time 2024-01-01T00:00:00Z --type product
+gpd purchases products acknowledge --package com.example.app --product-id sku123 --token TOKEN
+gpd purchases products consume --package com.example.app --product-id sku123 --token TOKEN
+gpd purchases subscriptions cancel --package com.example.app --subscription-id sub123 --token TOKEN
+gpd purchases subscriptions refund --package com.example.app --subscription-id sub123 --token TOKEN
+```
+
+## Permissions
+
+```bash
+gpd permissions users list --developer-id DEV_ID
+gpd permissions users create --developer-id DEV_ID --email user@example.com --developer-permissions CAN_VIEW_FINANCIAL_DATA_GLOBAL
+gpd permissions grants create --package com.example.app --email user@example.com --app-permissions CAN_REPLY_TO_REVIEWS
+```
+
+## Analytics
+
+```bash
+gpd analytics query --package com.example.app --start-date 2024-01-01 --end-date 2024-01-31
+```
+
+## Migration
+
+### Fastlane Supply
+
+```bash
+gpd migrate fastlane validate --dir fastlane/metadata/android
+gpd migrate fastlane export --package com.example.app --output fastlane/metadata/android
+gpd migrate fastlane export --package com.example.app --include-images --locales en-US,de-DE
+gpd migrate fastlane import --package com.example.app --dir fastlane/metadata/android
+gpd migrate fastlane import --package com.example.app --dir fastlane/metadata/android --replace-images
+gpd migrate fastlane import --package com.example.app --dir fastlane/metadata/android --skip-images --dry-run
+```
+
+## Agent Best Practices
+
+1. **JSON output by default** - all commands output minified JSON
+2. **Use `--pretty`** for readable JSON during debugging
+3. **Use `--dry-run`** before destructive operations
+4. **Check exit codes**: 0=success, 2=auth failure, 3=permission denied, 4=validation error, 5=rate limited, 6=network error, 7=not found, 8=conflict
+5. **Use edit lifecycle** for complex multi-step publishing with `--edit-id` and `--no-auto-commit`
+
+## Common Workflows
+
+### Deploy to Internal Track
+
+```bash
+gpd publish upload app.aab --package com.example.app
+gpd publish release --package com.example.app --track internal --status completed
+```
+
+### Staged Rollout to Production
+
+```bash
+gpd publish release --package com.example.app --track production --status inProgress --version-code 123
+gpd publish rollout --package com.example.app --track production --percentage 5
+gpd publish rollout --package com.example.app --track production --percentage 50
+gpd publish rollout --package com.example.app --track production --percentage 100
+```
+
+### Monitor App Health
+
+```bash
+gpd vitals crashes --package com.example.app --start-date 2024-01-01 --end-date 2024-01-31
+gpd reviews list --package com.example.app --min-rating 1 --max-rating 2
+```
+
+### Migrate from Fastlane
+
+```bash
+gpd migrate fastlane validate --dir fastlane/metadata/android
+gpd migrate fastlane import --package com.example.app --dir fastlane/metadata/android --dry-run
+gpd migrate fastlane import --package com.example.app --dir fastlane/metadata/android
+```

--- a/skills/gpd-id-resolver/SKILL.md
+++ b/skills/gpd-id-resolver/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: gpd-id-resolver
+description: Resolve Google Play identifiers (package, tracks, version codes, products, subscriptions) using gpd. Use when commands require IDs or exact values.
+---
+
+# GPD ID Resolver
+
+Use this skill to map names to IDs needed by other gpd commands.
+
+## Package name (app ID)
+- Package name is the primary identifier: `com.example.app`.
+- Always pass `--package` explicitly for deterministic results.
+
+## Track names
+- Common tracks: `internal`, `alpha`, `beta`, `production`.
+- List tracks:
+  - `gpd publish tracks --package com.example.app`
+
+## Version codes and release status
+- Use release status to find version codes on a track:
+  - `gpd publish status --package com.example.app --track production`
+
+## Tester groups
+- List testers by track:
+  - `gpd publish testers list --package com.example.app --track internal`
+
+## Monetization IDs
+- Products:
+  - `gpd monetization products list --package com.example.app`
+  - `gpd monetization products get sku123 --package com.example.app`
+- One-time products:
+  - `gpd monetization onetimeproducts list --package com.example.app`
+- Subscriptions:
+  - `gpd monetization subscriptions list --package com.example.app`
+  - `gpd monetization subscriptions get sub123 --package com.example.app`
+- Base plans and offers:
+  - `gpd monetization baseplans migrate-prices --package com.example.app sub123 plan456 --region-code US --price-micros 9990000`
+  - `gpd monetization offers list --package com.example.app sub123 plan456`
+
+## Permissions IDs
+- Developer users:
+  - `gpd permissions users list --developer-id DEV_ID`
+- App grants:
+  - `gpd permissions grants create --package com.example.app --email user@example.com --app-permissions CAN_REPLY_TO_REVIEWS`
+
+## Output tips
+- JSON is default; use `--pretty` for debugging.
+- Use `--all` on list commands to avoid missing items.

--- a/skills/gpd-metadata-sync/SKILL.md
+++ b/skills/gpd-metadata-sync/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: gpd-metadata-sync
+description: Sync and validate Google Play metadata, listings, and assets with gpd, including Fastlane-style workflows. Use when updating store listings or translations.
+---
+
+# GPD Metadata Sync
+
+Use this skill to keep local metadata in sync with Google Play.
+
+## Store listing fields
+
+```bash
+gpd publish listing get --package com.example.app
+gpd publish listing update --package com.example.app --locale en-US --title "My App"
+gpd publish details get --package com.example.app
+gpd publish details update --package com.example.app --contact-email support@example.com
+```
+
+## Images and assets
+
+```bash
+gpd publish images list phoneScreenshots --package com.example.app --locale en-US
+gpd publish images upload icon icon.png --package com.example.app --locale en-US
+gpd publish images delete phoneScreenshots IMAGE_ID --package com.example.app --locale en-US
+gpd publish images deleteall featureGraphic --package com.example.app --locale en-US
+gpd publish assets upload ./assets --package com.example.app
+gpd publish assets spec
+```
+
+## Fastlane metadata workflow
+
+### Export current state
+```bash
+gpd migrate fastlane export --package com.example.app --output fastlane/metadata/android
+```
+
+### Validate local files
+```bash
+gpd migrate fastlane validate --dir fastlane/metadata/android
+```
+
+### Import updates
+```bash
+gpd migrate fastlane import --package com.example.app --dir fastlane/metadata/android
+```
+
+### Import with options
+```bash
+gpd migrate fastlane import --package com.example.app --dir fastlane/metadata/android --replace-images
+gpd migrate fastlane import --package com.example.app --dir fastlane/metadata/android --skip-images --dry-run
+```
+
+## Multi-language workflow
+
+1. Export localizations:
+```bash
+gpd migrate fastlane export --package com.example.app --output fastlane/metadata/android
+```
+
+2. Translate files in `fastlane/metadata/android`.
+
+3. Import all at once:
+```bash
+gpd migrate fastlane import --package com.example.app --dir fastlane/metadata/android
+```
+
+## Notes
+- Use `gpd migrate fastlane validate` before import to catch missing fields.
+- Use `--dry-run` when available before overwriting assets.

--- a/skills/gpd-ppp-pricing/SKILL.md
+++ b/skills/gpd-ppp-pricing/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: gpd-ppp-pricing
+description: Set region-specific pricing for Google Play subscriptions and products using gpd monetization commands. Use when adjusting prices by territory or PPP strategy.
+---
+
+# PPP Pricing (Per-Region Pricing)
+
+Use this skill to set different prices per region for subscriptions and one-time products.
+
+## Preconditions
+- Ensure credentials are set (`GPD_SERVICE_ACCOUNT_KEY`).
+- Use `--package` explicitly.
+- Know target region codes and price micros.
+
+## Subscription base plan pricing
+
+### Migrate prices for a base plan
+```bash
+gpd monetization baseplans migrate-prices --package com.example.app sub123 plan456 --region-code US --price-micros 9990000
+```
+
+### Batch migrate prices
+```bash
+gpd monetization baseplans batch-migrate-prices --package com.example.app sub123 --file migrate.json
+```
+
+Example `migrate.json`:
+```json
+{
+  "requests": [
+    {
+      "basePlanId": "plan456",
+      "regionalPriceMigrations": [
+        {
+          "regionCode": "US",
+          "priceMicros": 9990000
+        }
+      ]
+    }
+  ],
+  "regionsVersion": {
+    "version": "2024-01-01"
+  }
+}
+```
+
+## One-time products pricing
+
+```bash
+gpd monetization onetimeproducts create --package com.example.app --product-id sku123 --type consumable
+gpd monetization onetimeproducts update --package com.example.app sku123 --default-price 1990000
+```
+
+## Offers and regional variants
+
+```bash
+gpd monetization offers list --package com.example.app sub123 plan456
+gpd monetization offers create --package com.example.app sub123 plan456 --offer-id offer789 --file offer.json
+gpd monetization offers batchUpdate --package com.example.app sub123 plan456 --file offers.json
+```
+
+## Verify current pricing
+
+```bash
+gpd monetization subscriptions get sub123 --package com.example.app
+gpd monetization baseplans batch-update-states --package com.example.app sub123 --file states.json
+```
+
+## Notes
+- Use `priceMicros` values to avoid rounding errors.
+- Keep region codes consistent (for example: `US`, `GB`, `IN`, `BR`).
+- Use batch files for large region sets to avoid partial updates.

--- a/skills/gpd-release-flow/SKILL.md
+++ b/skills/gpd-release-flow/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: gpd-release-flow
+description: End-to-end release workflows for Google Play using gpd publish commands, tracks, rollouts, and edit lifecycle. Use when uploading builds or managing releases.
+---
+
+# Release flow (Google Play)
+
+Use this skill when you need to upload a build, publish to a track, or manage rollout.
+
+## Preconditions
+- Ensure credentials are set (`GPD_SERVICE_ACCOUNT_KEY`).
+- Use a new version code for each upload.
+- Always pass `--package` explicitly.
+
+## Preferred end-to-end commands
+
+### Upload and release to a track
+```bash
+gpd publish upload app.aab --package com.example.app
+gpd publish release --package com.example.app --track internal --status completed
+```
+
+### Promote between tracks
+```bash
+gpd publish promote --package com.example.app --from-track beta --to-track production
+```
+
+## Manual sequence with edit lifecycle
+Use when you need precise control or multiple changes in one commit.
+
+```bash
+# 1. Create edit
+EDIT_ID=$(gpd publish edit create --package com.example.app | jq -r '.data.editId')
+
+# 2. Upload build without auto-commit
+gpd publish upload app.aab --package com.example.app --edit-id $EDIT_ID --no-auto-commit
+
+# 3. Configure release
+gpd publish release --package com.example.app --track internal --status draft --edit-id $EDIT_ID
+
+# 4. Validate and commit
+gpd publish edit validate $EDIT_ID --package com.example.app
+gpd publish edit commit $EDIT_ID --package com.example.app
+```
+
+## Staged rollout
+```bash
+gpd publish release --package com.example.app --track production --status inProgress --version-code 123
+gpd publish rollout --package com.example.app --track production --percentage 5
+gpd publish rollout --package com.example.app --track production --percentage 50
+gpd publish rollout --package com.example.app --track production --percentage 100
+```
+
+## Halt or rollback
+```bash
+gpd publish halt --package com.example.app --track production --confirm
+gpd publish rollback --package com.example.app --track production --confirm
+```
+
+## Track status
+```bash
+gpd publish status --package com.example.app --track production
+gpd publish tracks --package com.example.app
+```
+
+## Notes
+- Use `--status draft` first for risky releases.
+- Use `--confirm` only after reviewing `gpd publish status` output.

--- a/skills/gpd-submission-health/SKILL.md
+++ b/skills/gpd-submission-health/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: gpd-submission-health
+description: Preflight Google Play releases, validate edits, and verify listing completeness with gpd. Use when shipping to production or troubleshooting a failed release.
+---
+
+# GPD Submission Health
+
+Use this skill to reduce Play Console submission failures and validate readiness.
+
+## Preconditions
+- Auth configured and package name resolved.
+- Build uploaded and available for the target track.
+- Store listing metadata and assets updated.
+
+## Pre-submission checklist
+
+### 1. Validate edit (if using edit lifecycle)
+```bash
+gpd publish edit validate EDIT_ID --package com.example.app
+```
+
+### 2. Confirm release status
+```bash
+gpd publish status --package com.example.app --track production
+```
+Check:
+- Release status is expected (`draft`, `inProgress`, or `completed`).
+- Version code matches the uploaded build.
+
+### 3. Verify store listing metadata
+```bash
+gpd publish listing get --package com.example.app
+gpd publish details get --package com.example.app
+```
+
+### 4. Verify screenshots and assets
+```bash
+gpd publish images list phoneScreenshots --package com.example.app --locale en-US
+gpd publish assets spec
+```
+
+### 5. Upload deobfuscation mapping (if needed)
+```bash
+gpd publish deobfuscation upload mapping.txt --package com.example.app --type proguard --version-code 123
+```
+
+## Submit to production
+```bash
+gpd publish release --package com.example.app --track production --status inProgress --version-code 123
+```
+
+## Common submission issues
+
+### Release not in valid state
+Check:
+1. Version code uploaded and attached to the track.
+2. Edit validation passes.
+3. Required store listing fields present for all locales.
+
+### Missing screenshots or assets
+Use:
+```bash
+gpd publish images list phoneScreenshots --package com.example.app --locale en-US
+gpd publish images upload icon icon.png --package com.example.app --locale en-US
+```
+
+### Policy declarations not complete
+Some policy/compliance items must be completed in Play Console UI. Confirm in the console if CLI operations pass but submission is blocked.
+
+## Notes
+- Use `gpd publish edit validate` before committing large changes.
+- Use `--dry-run` where available before destructive actions.


### PR DESCRIPTION
This PR adds comprehensive Agent Skills for the Google Play Developer CLI (gpd), the Android equivalent to the App Store Connect CLI.

## New Skills Added
- **gpd-cli**: Main entry point for Google Play automation
- **gpd-cli-usage**: Command discovery, flags, auth, and output conventions
- **gpd-release-flow**: End-to-end track releases and rollouts
- **gpd-betagroups**: Beta testing groups and distribution
- **gpd-build-lifecycle**: Build processing and release state
- **gpd-submission-health**: Preflight checks and validation
- **gpd-metadata-sync**: Listings, assets, and metadata management
- **gpd-ppp-pricing**: Regional pricing workflows
- **gpd-id-resolver**: Package, track, and monetization ID resolution

## Audit Fixes Applied (from PR #17 review)
- **High**: Fixed jq extraction path in gpd-release-flow (`.id` → `.data.editId`)
- **High**: Fixed JSON schema in gpd-ppp-pricing for batch-migrate-prices (correct API structure)
- **Medium**: Replaced deprecated `--paginate` with `--all` in gpd-cli-usage and gpd-id-resolver

## Key Features
- JSON-first output (consistent with asc CLI)
- Service account authentication support
- Track management (internal, alpha, beta, production)
- Staged rollouts
- Edit lifecycle for atomic operations
- Beta group orchestration
- Metadata sync (including Fastlane migration)

## Related
- Google Play Developer CLI: https://github.com/dl-alexandre/Google-Play-Developer-CLI
- Addresses audit feedback from PR #17