### PR TITLE
Add asc-crash-triage skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ Archive, export, and notarize macOS apps with Developer ID signing.
 - You want the full flow: archive → Developer ID export → zip → notarize → staple
 - You're troubleshooting Developer ID signing or trust chain issues
 
+### asc-crash-triage
+
+Triage TestFlight crashes, beta feedback, and performance diagnostics.
+
+**Use when:**
+- You want to review recent TestFlight crash reports
+- You need a crash summary grouped by signature, device, and build
+- You want to check beta tester feedback and screenshots
+- You need performance diagnostics (hangs, disk writes, launches) for a build
+
 ## Installation
 
 Install this skill pack:

--- a/skills/asc-crash-triage/SKILL.md
+++ b/skills/asc-crash-triage/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: asc-crash-triage
+description: Triage TestFlight crashes, beta feedback, and performance diagnostics using asc. Use when the user asks about TF crashes, TestFlight crash reports, beta tester feedback, app hangs, disk writes, launch diagnostics, or wants a crash summary for a build or app.
+---
+
+# asc crash triage
+
+Use this skill to fetch, analyze, and summarize TestFlight crash reports, beta feedback, and performance diagnostics.
+
+## Workflow
+
+1. Resolve the app ID if not provided (use `asc apps list`).
+2. Fetch data with the appropriate command.
+3. Parse JSON output and present a human-readable summary.
+
+## TestFlight crash reports
+
+List recent crashes (newest first):
+
+- `asc crashes --app "APP_ID" --sort -createdDate --limit 10`
+- Filter by build: `asc crashes --app "APP_ID" --build "BUILD_ID" --sort -createdDate --limit 10`
+- Filter by device/OS: `asc crashes --app "APP_ID" --device-model "iPhone16,2" --os-version "18.0"`
+- All crashes: `asc crashes --app "APP_ID" --paginate`
+- Table view: `asc crashes --app "APP_ID" --sort -createdDate --limit 10 --output table`
+
+## TestFlight beta feedback
+
+List recent feedback (newest first):
+
+- `asc feedback --app "APP_ID" --sort -createdDate --limit 10`
+- With screenshots: `asc feedback --app "APP_ID" --sort -createdDate --limit 10 --include-screenshots`
+- Filter by build: `asc feedback --app "APP_ID" --build "BUILD_ID" --sort -createdDate`
+- All feedback: `asc feedback --app "APP_ID" --paginate`
+
+## Performance diagnostics (hangs, disk writes, launches)
+
+Requires a build ID. Resolve via `asc builds latest --app "APP_ID" --platform IOS` or `asc builds list --app "APP_ID" --sort -uploadedDate --limit 5`.
+
+- List diagnostic signatures: `asc performance diagnostics list --build "BUILD_ID"`
+- Filter by type: `asc performance diagnostics list --build "BUILD_ID" --diagnostic-type "HANGS"`
+  - Types: `HANGS`, `DISK_WRITES`, `LAUNCHES`
+- Get logs for a signature: `asc performance diagnostics get --id "SIGNATURE_ID"`
+- Download all metrics: `asc performance download --build "BUILD_ID" --output ./metrics.json`
+
+## Resolving IDs
+
+- App ID from name: `asc apps list --name "AppName"` or `asc apps list --bundle-id "com.example.app"`
+- Latest build ID: `asc builds latest --app "APP_ID" --platform IOS`
+- Recent builds: `asc builds list --app "APP_ID" --sort -uploadedDate --limit 5`
+- Set default: `export ASC_APP_ID="APP_ID"`
+
+## Summary format
+
+When presenting results, organize by severity and frequency:
+
+1. **Total count** — how many crashes/feedbacks in the result set.
+2. **Top crash signatures** — group by exception type or crash reason, ranked by count.
+3. **Affected builds** — which build versions are impacted.
+4. **Device & OS breakdown** — most affected device models and OS versions.
+5. **Timeline** — when crashes started or spiked.
+
+For performance diagnostics, highlight the highest-weight signatures first.
+
+## Notes
+
+- Default output is JSON; use `--output table` or `--output markdown` for quick human review.
+- Use `--paginate` to fetch all pages when doing a full analysis.
+- Use `--pretty` with JSON for debugging command output.
+- Crash data from App Store Connect may have 24-48h delay.


### PR DESCRIPTION
## Summary

- Add new `asc-crash-triage` skill for triaging TestFlight crashes, beta feedback, and performance diagnostics
- Covers three key workflows:
  - **TestFlight crash reports**: `asc crashes` — list, filter by build/device/OS, sort by date
  - **Beta tester feedback**: `asc feedback` — list feedback with optional screenshot URLs
  - **Performance diagnostics**: `asc performance diagnostics` — hangs, disk writes, launch diagnostics per build
- Includes guidance on ID resolution, output formatting, and a structured summary format for agent responses
- Updates README.md with the new skill entry

## Skill Structure

```
skills/asc-crash-triage/
└── SKILL.md
```

## Test plan

- [ ] Install skill pack and verify `asc-crash-triage` triggers on crash/feedback queries
- [ ] Run `asc crashes --app <APP_ID> --sort -createdDate --limit 10` to verify command correctness
- [ ] Run `asc feedback --app <APP_ID> --sort -createdDate --limit 10` to verify feedback retrieval
- [ ] Run `asc performance diagnostics list --build <BUILD_ID>` to verify diagnostics flow