### PR TITLE
Add asc-wall-submit skill for Wall submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,15 @@ Triage TestFlight crashes, beta feedback, and performance diagnostics.
 - You want to check beta tester feedback and screenshots
 - You need performance diagnostics (hangs, disk writes, launches) for a build
 
+### asc-wall-submit
+
+Submit or update an app entry in the App-Store-Connect-CLI Wall of Apps using the existing generate-and-PR workflow.
+
+**Use when:**
+- You want to add your app to the Wall of Apps
+- You want to update an existing Wall entry
+- You want the exact `make generate app` + PR submission flow
+
 ## Installation
 
 Install this skill pack:

--- a/skills/asc-wall-submit/SKILL.md
+++ b/skills/asc-wall-submit/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: asc-wall-submit
+description: Submit or update a Wall of Apps entry in the App-Store-Connect-CLI repository using the existing generate-and-PR flow. Use when the user says "submit to wall of apps", "add my app to the wall", "wall-of-apps", or asks for make generate app + PR help.
+---
+
+# asc wall submit
+
+Use this skill to add or update a Wall of Apps entry without introducing new CLI surface area.
+
+## When to use
+
+- User wants to submit an app to the Wall of Apps
+- User wants to update an existing Wall of Apps entry
+- User asks for the exact Wall submission flow
+
+## Required inputs
+
+Collect and confirm all fields before running commands:
+
+- `app`: app name
+- `link`: app URL (`http`/`https`, usually App Store URL)
+- `creator`: GitHub handle or creator name
+- `platform`: comma-separated labels (for example: `iOS,macOS`)
+
+If any value is missing, ask for it first.
+
+## Submission workflow
+
+1. Run commands from the `App-Store-Connect-CLI` repository root.
+2. Run:
+   `make generate app APP="Your App Name" LINK="https://apps.apple.com/app/id1234567890" CREATOR="your-handle" PLATFORM="iOS,macOS"`
+3. Verify generated changes include:
+   - `docs/wall-of-apps.json`
+   - `README.md`
+4. Review diff and confirm:
+   - The JSON entry is added or updated correctly.
+   - The README wall snippet is regenerated from markers.
+5. Open a focused PR with only the Wall-related generated changes.
+
+## Guardrails
+
+- Do not hand-edit the Wall snippet in `README.md`.
+- Do not modify unrelated entries in `docs/wall-of-apps.json`.
+- If generation fails due to invalid input, fix inputs and rerun the generator.
+- Keep submission path PR-based unless maintainers define an issue-based intake flow.
+
+## Examples
+
+Add new app:
+
+`make generate app APP="My App" LINK="https://apps.apple.com/app/id1234567890" CREATOR="my-handle" PLATFORM="iOS"`
+
+Update existing app (same app name updates in place):
+
+`make generate app APP="My App" LINK="https://apps.apple.com/app/id1234567890" CREATOR="my-handle" PLATFORM="iOS,macOS"`


### PR DESCRIPTION
## Summary
- add a new `asc-wall-submit` skill under `skills/` to guide users through the existing Wall of Apps submission workflow
- document required inputs and guardrails for `make generate app` plus PR submission
- update `README.md` to list the new skill under Available Skills

## Test plan
- [x] Verified skill file exists at `skills/asc-wall-submit/SKILL.md`
- [x] Verified README includes `asc-wall-submit` in Available Skills
- [x] Reviewed `git diff main...HEAD` to confirm only the intended two files changed