### PR TITLE
feat: add asc-aso-audit skill

### DIFF
--- a/skills/asc-aso-audit/SKILL.md
+++ b/skills/asc-aso-audit/SKILL.md
@@ -40,9 +40,12 @@ Example:  "quran" appears in subtitle AND keywords — remove from keywords to f
 How to check:
 1. Read `metadata/app-info/{locale}.json` for `subtitle` (and `name` if present)
 2. Read `metadata/version/{latest-version}/{locale}.json` for `keywords`
-3. Lowercase and tokenize subtitle (+ name) by whitespace, then strip leading/trailing punctuation from each token
+3. Tokenize subtitle (+ name):
+   - **Latin/Cyrillic scripts:** split by whitespace, strip leading/trailing punctuation, lowercase
+   - **Chinese/Japanese/Korean:** split by `、` `，` `,` or iterate characters — each character or character-group is a token. Whitespace tokenization does not work for CJK.
+   - **Arabic:** split by whitespace, then also generate prefix-stripped variants (remove ال prefix) since Apple likely normalizes definite articles. For example, "القرآن" in subtitle should flag both "القرآن" and "قرآن" in keywords.
 4. Split keywords by comma, trim whitespace, lowercase
-5. Report intersection
+5. Report intersection (including fuzzy matches from prefix stripping)
 
 ### 2. Underutilized Fields
 
@@ -95,24 +98,55 @@ How to check:
 2. Compare each non-primary locale against the primary
 3. Flag exact matches (case-insensitive)
 
+### 6. Description Keyword Coverage
+
+Check whether keywords appear naturally in the `description` field. While Apple does **not** index descriptions for search, users who see their search terms reflected in the description are more likely to download — this improves conversion rate, which indirectly boosts rankings.
+
+```
+Severity: 💡 Info
+Example:  3 of 16 keywords not found in description: namaz, tarteel, adhan
+```
+
+How to check:
+1. Load `keywords` and `description` for each locale
+2. For each keyword, check if it appears as a substring in the description (case-insensitive)
+3. Account for inflected forms: Arabic root matches, verb conjugations (e.g., "memorizar" ≈ "memorices"), and case declensions (e.g., Russian "сура" ≈ "суры")
+4. Report missing keywords per locale — recommend weaving them naturally into existing sentences
+5. Do NOT flag: Latin-script keywords in non-Latin descriptions (e.g., "quran" in Cyrillic text) — these target separate search paths
+
 ## Phase 2: Astro MCP Keyword Gap Analysis
 
-If Astro MCP is available and the app is tracked, run keyword gap analysis.
+If Astro MCP is available and the app is tracked, run keyword gap analysis. **Run this per store/locale, not just for the US store** — keyword popularity varies dramatically across markets.
 
 ### Steps
 
 1. **Get current keywords**: Call `get_app_keywords` with the app ID to retrieve tracked keywords and their current rankings.
 
-2. **Get suggestions**: Call `get_keyword_suggestions` with the app ID to get Astro's recommended keywords based on category and competitor analysis.
+2. **Ensure multi-store tracking**: For each locale with a corresponding App Store territory (e.g., `ar-SA` → Saudi Arabia, `fr-FR` → France, `tr` → Turkey), use `add_keywords` to add keyword tracking in that store. Without this, `search_rankings` returns empty for non-US stores.
 
-3. **Diff against metadata**: Compare suggested keywords against the tokens present in `subtitle`, `name` (if available), and `keywords` fields from the local metadata.
+3. **Extract competitor keywords**: Call `extract_competitors_keywords` with 3-5 top competitor app IDs to find keyword gaps. This is the highest-value Astro tool — it reveals keywords competitors rank for that you don't. Run this per store when possible.
 
-4. **Surface gaps**: Report all suggestions not present in any metadata field, ranked by popularity score (highest first).
+4. **Get suggestions**: Call `get_keyword_suggestions` with the app ID for additional recommendations based on category analysis.
+
+5. **Check current rankings**: Call `search_rankings` to see where the app currently ranks for tracked keywords in each store.
+
+6. **Diff against metadata**: Compare suggested and competitor keywords against the tokens present in `subtitle`, `name` (if available), and `keywords` fields from the local metadata.
+
+7. **Surface gaps**: Report all gaps ranked by popularity score (highest first). Include the source (competitor analysis vs. suggestion).
+
+### Cross-Field Combo Strategy
+
+When recommending keyword additions, consider how single words combine across indexed fields (title + subtitle + keywords). For example:
+- Adding "namaz" to keywords when "vakti" is already present enables matching the search "namaz vakti" (66 popularity)
+- Adding "holy" to keywords when "Quran" is in the subtitle enables matching "holy quran" (58 popularity)
+
+Flag high-value combos in recommendations.
 
 ### Skip Conditions
 
 - Astro MCP not connected → skip with note: "Connect Astro MCP for keyword gap analysis"
 - App not tracked in Astro → skip with note: "Add app to Astro with `mcp__astro__add_app` for gap analysis"
+- Store not tracked for a locale → add tracking with `add_keywords` before querying
 
 ## Output Format
 

--- a/skills/asc-aso-audit/references/aso_rules.md
+++ b/skills/asc-aso-audit/references/aso_rules.md
@@ -5,9 +5,11 @@ Rules enforced by the asc-aso-audit skill. Each rule links to the check that tes
 ## Indexing Rules
 
 - **Title, subtitle, and keyword field are indexed** for App Store search.
-- **Description and promotional text are NOT indexed.** Description is for conversion; promotional text is for seasonal messaging.
+- **Description and promotional text are NOT indexed.** Description is for conversion (users see search terms reflected → higher download rate); promotional text is for seasonal messaging.
+- **Description keyword coverage still matters** — while not indexed, descriptions that naturally include keyword terms improve conversion rate, which indirectly boosts search rankings.
 - **Screenshot captions are OCR-indexed** (since June 2025 algorithm update). Use high-value keywords in caption text. *(Informational — not checked by this audit.)*
 - **Apple Full Text Search combines words across title + subtitle + keywords.** Single words enable more combinations than multi-word phrases. Example: "quran" + "recitation" in separate fields still matches "quran recitation".
+- **Cross-field combo optimization:** When adding keywords, consider what search queries they enable in combination with words already in title/subtitle. Example: adding "holy" to keywords when "Quran" is in subtitle enables the search "holy quran".
 
 ## Keyword Field Rules
 
@@ -15,6 +17,8 @@ Rules enforced by the asc-aso-audit skill. Each rule links to the check that tes
 - **Do not duplicate words already in title or subtitle.** Apple indexes all three fields together; repeating a word wastes keyword budget.
 - **Do not use the app name in keywords.** It is already indexed.
 - **Avoid plurals if the singular is already present** — Apple handles stemming.
+- **Prefer single words over multi-word phrases** — single words enable more cross-field combinations and use fewer characters.
+- **Always validate with popularity data** — never guess keyword value. Use Astro MCP or similar tools to check popularity scores before making swaps.
 
 ## Character Limits
 
@@ -32,6 +36,15 @@ Rules enforced by the asc-aso-audit skill. Each rule links to the check that tes
 - **Localize keywords per market** — do not just translate your primary keywords. Research what users in each locale actually search for.
 - **English (US) keywords may carry into other English-speaking storefronts** but dedicated localization always outperforms.
 - **Identical keyword fields across locales** usually indicates untranslated/unlocalized metadata.
+- **Track keywords in each locale's store** — keyword popularity varies dramatically across territories. A keyword with 70 popularity in the US store may have 5 popularity in France. Use Astro `add_keywords` to set up tracking per store before analyzing.
+- **Use competitor analysis per store** — top competitors differ by market. Run `extract_competitors_keywords` with locale-relevant competitor apps.
+
+## Non-Latin Script Rules
+
+- **Arabic ال-prefix:** Apple likely normalizes the definite article ال. Treat "القرآن" (with ال) and "قرآن" (without) as probable duplicates when checking subtitle/keyword overlap.
+- **Arabic hamza variants:** Users commonly search without hamza diacritics. "قران" (no hamza) and "قرآن" (with hamza) target different search queries — both may be worth including.
+- **Chinese tokenization:** Chinese text has no word-separating spaces. Subtitle tokens are separated by `、` (enumeration comma) or `，` (full comma). Do not use whitespace tokenization for Chinese metadata.
+- **Cyrillic transliteration:** Including the Latin spelling of terms (e.g., "quran" in a Russian keyword field) targets users who search in Latin script on Cyrillic storefronts.
 
 ## Utilization Guidelines
 


### PR DESCRIPTION
## Summary

Adds a new `asc-aso-audit` skill that runs a two-phase ASO (App Store Optimization) audit on locally pulled App Store metadata.

- **Phase 1 — Offline Checks (6 checks):** keyword waste detection, field utilization, missing fields, bad separators, cross-locale gaps, and description keyword coverage
- **Phase 2 — Astro MCP Integration:** multi-store keyword gap analysis via competitor extraction, keyword suggestions, and search rankings
- **References:** includes `aso_rules.md` with indexing rules, character limits, localization rules, and non-Latin script handling (Arabic, Chinese, Cyrillic)

### Key features
- Works offline with just local metadata files — no network needed for Phase 1
- Non-Latin script support: Arabic ال-prefix normalization, hamza variants, CJK tokenization, Cyrillic transliteration
- Cross-field combo strategy: identifies high-value keyword combinations across title + subtitle + keywords
- Multi-store Astro analysis: tracks and analyzes keywords per locale's actual App Store territory, not just US
- Description keyword coverage check for conversion optimization

### Files
- `skills/asc-aso-audit/SKILL.md` — main skill file
- `skills/asc-aso-audit/references/aso_rules.md` — ASO rules reference

## Test plan
- [ ] Run skill against an app with exported metadata via `asc migrate export`
- [ ] Verify Phase 1 offline checks detect keyword waste, underutilized fields, and bad separators
- [ ] Verify Phase 2 Astro integration surfaces keyword gaps when Astro MCP is connected
- [ ] Verify non-Latin script tokenization works for Arabic, Chinese, and Cyrillic metadata