### PR TITLE
docs: align release-flow readiness guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,17 +95,17 @@ Build my iOS app, capture the home and settings screens in the simulator, frame 
 
 ### asc-release-flow
 
-End-to-end release workflows for TestFlight and App Store.
+Readiness-first App Store submission guidance, including first-time release blockers.
 
 **Use when:**
-- You want to upload, distribute, and submit in one flow
-- You need the manual sequence for fine-grained control
-- You're releasing for iOS, macOS, visionOS, or tvOS
+- You want the quickest answer to "can I submit this app now?"
+- You need to separate API-fixable, web-session-fixable, and manual blockers
+- You're handling first-time submission issues around availability, IAPs, subscriptions, Game Center, or App Privacy
 
 **Example:**
 
 ```bash
-Publish version 2.4.0 of my iOS app to TestFlight for the Beta Testers group and wait for processing.
+Check whether version 2.4.0 of my iOS app is ready for App Store submission, show the blockers, and tell me the next `asc` command to run.
 ```
 
 ### asc-signing-setup

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -10,6 +10,7 @@ Use this skill when the real question is "Can my app be ready to submit?" and th
 ## Preconditions
 - Ensure credentials are set (`asc auth login` or `ASC_*` env vars).
 - Resolve app ID, version string, and build ID up front.
+- For lower-level or first-time flows, also be ready to resolve `VERSION_ID`, `SUBMISSION_ID`, `DETAIL_ID`, `GROUP_ID`, `SUB_ID`, `IAP_ID`, and related resource IDs. Use `asc-id-resolver` when needed.
 - Have a metadata directory ready if you plan to use `asc release run`.
 - If you use experimental web-session commands, use a user-owned Apple Account session and treat those commands as optional escape hatches, not the default path.
 
@@ -64,6 +65,8 @@ Run this when the user needs a fuller version-level checklist than `submit prefl
 ```bash
 asc validate --app "APP_ID" --version "1.2.3" --platform IOS --output table
 ```
+
+Prefer the version string form here so it stays aligned with `asc submit preflight` and `asc release run`. Switch to `VERSION_ID` only for lower-level commands that explicitly require it.
 
 If the app sells digital goods, also run:
 
@@ -285,7 +288,9 @@ Use the lower-level flow only when the user needs explicit control over each ste
 asc versions attach-build --version-id "VERSION_ID" --build "BUILD_ID"
 asc submit preflight --app "APP_ID" --version "1.2.3" --platform IOS
 asc submit create --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --confirm
-asc status --app "APP_ID"
+asc submit status --version-id "VERSION_ID"
+# or, if you captured the review submission ID:
+asc submit status --id "SUBMISSION_ID"
 ```
 
 If the submission needs multiple review items, such as Game Center component versions, use the review-submission API directly instead:

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -92,8 +92,10 @@ cannot verify whether App Privacy is fully published. Before final submission:
 
 ```bash
 asc submit preflight --app "APP_ID" --version "1.2.3" --platform IOS
-asc validate --app "APP_ID" --version-id "VERSION_ID" --platform IOS
+asc validate --app "APP_ID" --version "1.2.3" --platform IOS
 ```
+
+Prefer the version string form for top-level readiness checks in this skill so it stays aligned with `asc submit preflight`. Lower-level commands later in this guide still use `VERSION_ID` where the API requires it.
 
 If either command reports an App Privacy advisory, the public API cannot verify
 publish state. Use the web-session privacy workflow if you rely on those endpoints:


### PR DESCRIPTION
## Summary
- update `asc-release-flow` in the README so it routes users to readiness-first App Store submission help instead of generic release workflow guidance
- standardize the top-level `asc validate` examples on the version string form and explain when lower-level flows should still use `VERSION_ID`
- replace the ambiguous `asc status` fallback with submit-specific status commands and document the extra IDs needed for first-time and lower-level submission paths

## Test plan
- [x] Reviewed the rendered diff for `README.md`, `skills/asc-release-flow/SKILL.md`, and `skills/asc-submission-health/SKILL.md`
- [x] Verified `asc status --app` no longer appears in the repository
- [x] Verified the top-level `asc validate` examples are aligned across the two submission skills