### PR TITLE
docs: refresh release-readiness skills for latest asc workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npx skills add rudrankriyam/app-store-connect-cli-skills
 
 ### asc-cli-usage
 
-Guidance for running `asc` commands (flags, pagination, output, auth).
+Guidance for running `asc` commands (canonical verbs, flags, pagination, output, auth).
 
 **Use when:**
 - You need the correct `asc` command or flag combination
@@ -62,7 +62,7 @@ Create a new App Store Connect app for com.example.myapp with SKU MYAPP123 and p
 
 ### asc-xcode-build
 
-Build, archive, and export iOS/macOS apps with xcodebuild before uploading.
+Build, archive, export, and manage Xcode version/build numbers before uploading.
 
 **Use when:**
 - You need to create an IPA or PKG for upload
@@ -95,7 +95,7 @@ Build my iOS app, capture the home and settings screens in the simulator, frame 
 
 ### asc-release-flow
 
-Readiness-first App Store submission guidance, including first-time release blockers.
+Readiness-first App Store submission guidance, including `asc release stage`, `asc submit preflight`, and first-time release blockers.
 
 **Use when:**
 - You want the quickest answer to "can I submit this app now?"
@@ -110,7 +110,7 @@ Check whether version 2.4.0 of my iOS app is ready for App Store submission, sho
 
 ### asc-signing-setup
 
-Bundle IDs, capabilities, certificates, and provisioning profiles.
+Bundle IDs, capabilities, certificates, provisioning profiles, and encrypted signing sync.
 
 **Use when:**
 - You are onboarding a new app or bundle ID
@@ -198,7 +198,7 @@ Turn these release bullet points into polished What's New notes for en-US and lo
 
 ### asc-submission-health
 
-Preflight checks, submission, and review monitoring.
+Preflight checks, digital-goods readiness validation, submission, and review monitoring.
 
 **Use when:**
 - You want to reduce submission failures

--- a/skills/asc-app-create-ui/SKILL.md
+++ b/skills/asc-app-create-ui/SKILL.md
@@ -85,7 +85,7 @@ The platforms are **checkboxes** (not radio buttons). Click the checkbox for the
 
 ### 6. Verify creation via API
 ```bash
-asc apps get --id "APP_ID" --output json --pretty
+asc apps view --id "APP_ID" --output json --pretty
 # or
 asc apps list --bundle-id "com.example.app" --output json
 ```
@@ -94,8 +94,14 @@ asc apps list --bundle-id "com.example.app" --output json
 ```bash
 asc app-setup info set --app "APP_ID" --primary-locale "en-US"
 asc app-setup categories set --app "APP_ID" --primary GAMES
-asc app-setup availability set --app "APP_ID" --territory "USA,GBR" --available true
+asc pricing availability create \
+  --app "APP_ID" \
+  --territory "USA,GBR" \
+  --available true \
+  --available-in-new-territories true
 ```
+
+If app availability already exists, switch to `asc pricing availability edit --app "APP_ID" ...` for later territory changes.
 
 ## Known UI Automation Issues
 

--- a/skills/asc-cli-usage/SKILL.md
+++ b/skills/asc-cli-usage/SKILL.md
@@ -13,6 +13,17 @@ Use this skill when you need to run or design `asc` commands for App Store Conne
   - `asc builds --help`
   - `asc builds list --help`
 
+## Canonical verbs (0.45.x+)
+- Prefer `view` over legacy `get` aliases for read-only commands in docs and automation.
+  - `asc apps view --id "APP_ID"`
+  - `asc versions view --version-id "VERSION_ID"`
+  - `asc pricing availability view --app "APP_ID"`
+- Prefer `edit` for update-only availability surfaces and other canonical edit flows.
+  - `asc pricing availability edit --app "APP_ID" --territory "USA,GBR" --available true`
+  - `asc app-setup availability edit --app "APP_ID" --territory "USA,GBR" --available true`
+  - `asc xcode version edit --build-number "42"`
+- Keep `set` where the CLI intentionally models a higher-level replacement/configuration flow and `--help` still shows `set` as the canonical verb.
+
 ## Flag conventions
 - Use explicit long flags (e.g., `--app`, `--output`).
 - Prefer explicit flags in automation; some newer commands can prompt for missing fields when run interactively.
@@ -28,6 +39,9 @@ Use this skill when you need to run or design `asc` commands for App Store Conne
 - Prefer keychain auth via `asc auth login`.
 - Fallback env vars: `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY_PATH`, `ASC_PRIVATE_KEY`, `ASC_PRIVATE_KEY_B64`.
 - `ASC_APP_ID` can provide a default app ID.
+- When permissions are unclear, inspect exact API key role coverage with `asc web auth capabilities`.
+  - This lives under the experimental web auth surface.
+  - It can resolve the current local auth by default, or inspect a specific key with `--key-id`.
 
 ## Timeouts
 - `ASC_TIMEOUT` / `ASC_TIMEOUT_SECONDS` control request timeouts.

--- a/skills/asc-crash-triage/SKILL.md
+++ b/skills/asc-crash-triage/SKILL.md
@@ -39,7 +39,7 @@ Requires a build ID. Resolve via `asc builds latest --app "APP_ID" --platform IO
 - List diagnostic signatures: `asc performance diagnostics list --build "BUILD_ID"`
 - Filter by type: `asc performance diagnostics list --build "BUILD_ID" --diagnostic-type "HANGS"`
   - Types: `HANGS`, `DISK_WRITES`, `LAUNCHES`
-- Get logs for a signature: `asc performance diagnostics get --id "SIGNATURE_ID"`
+- View logs for a signature: `asc performance diagnostics view --id "SIGNATURE_ID"`
 - Download all metrics: `asc performance download --build "BUILD_ID" --output ./metrics.json`
 
 ## Resolving IDs

--- a/skills/asc-ppp-pricing/SKILL.md
+++ b/skills/asc-ppp-pricing/SKILL.md
@@ -190,7 +190,7 @@ asc iap pricing schedules create --iap-id "IAP_ID" --base-territory "USA" --pric
 Use these when you are intentionally creating or replacing schedule entries. For deeper inspection:
 
 ```bash
-asc iap pricing schedules get --iap-id "IAP_ID"
+asc iap pricing schedules view --iap-id "IAP_ID"
 asc iap pricing schedules manual-prices --schedule-id "SCHEDULE_ID" --paginate
 asc iap pricing schedules automatic-prices --schedule-id "SCHEDULE_ID" --paginate
 ```

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -11,7 +11,7 @@ Use this skill when the real question is "Can my app be ready to submit?" and th
 - Ensure credentials are set (`asc auth login` or `ASC_*` env vars).
 - Resolve app ID, version string, and build ID up front.
 - For lower-level or first-time flows, also be ready to resolve `VERSION_ID`, `SUBMISSION_ID`, `DETAIL_ID`, `GROUP_ID`, `SUB_ID`, `IAP_ID`, and related resource IDs. Use `asc-id-resolver` when needed.
-- Have a metadata directory ready if you plan to use `asc release run`.
+- Have a metadata directory ready if you plan to use `asc release stage` or `asc release run`.
 - If you use experimental web-session commands, use a user-owned Apple Account session and treat those commands as optional escape hatches, not the default path.
 
 ## How to answer
@@ -22,8 +22,8 @@ When using this skill, answer readiness questions in this order:
 4. What exact command should run next?
 
 Group blockers like this:
-- API-fixable: build validity, metadata, screenshots, review details, content rights, encryption, version/build attachment, IAP readiness, Game Center version and review-submission setup.
-- Web-session-fixable: initial app availability bootstrap, first-review subscription attachment, App Privacy publish state.
+- API-fixable: build validity, metadata, screenshots, review details, content rights, encryption, version/build attachment, app availability bootstrap, IAP readiness, Game Center version and review-submission setup.
+- Web-session-fixable: first-review subscription attachment, App Privacy publish state.
 - Manual fallback: first-time IAP selection from the app-version screen when no CLI attach flow exists, or any flow the user does not want to run through experimental web-session commands.
 
 ## Canonical path
@@ -37,7 +37,21 @@ asc submit preflight --app "APP_ID" --version "1.2.3" --platform IOS
 
 This is the fastest high-signal readiness check and prints fix guidance without mutating anything.
 
-### 2. Full-pipeline dry run
+### 2. Real staging pass without submit
+Run this when the user wants the version prepared in App Store Connect but wants a manual checkpoint before creating a review submission:
+
+```bash
+asc release stage \
+  --app "APP_ID" \
+  --version "1.2.3" \
+  --build "BUILD_ID" \
+  --metadata-dir "./metadata/version/1.2.3" \
+  --confirm
+```
+
+Use `--copy-metadata-from "1.2.2"` instead of `--metadata-dir` when you want to carry metadata forward from an existing version. `asc release stage` requires exactly one metadata source and stops before submit.
+
+### 3. Full-pipeline dry run
 Run this when the user wants one command that approximates the whole release path:
 
 ```bash
@@ -59,7 +73,7 @@ This is the best single-command rehearsal for:
 
 Add `--strict-validate` when you want warnings treated as blockers.
 
-### 3. Deep API readiness audit
+### 4. Deep API readiness audit
 Run this when the user needs a fuller version-level checklist than `submit preflight`:
 
 ```bash
@@ -75,7 +89,11 @@ asc validate iap --app "APP_ID" --output table
 asc validate subscriptions --app "APP_ID" --output table
 ```
 
-### 4. Actual submit
+In `0.45.3+`, `asc validate subscriptions` expands `MISSING_METADATA` into per-subscription diagnostics. Use it to pinpoint missing review screenshots, promotional images, pricing or availability coverage, offer readiness, and app/build evidence before you retry submission or `attach-group`.
+
+When territory coverage is wrong, the newest diagnostics name the exact missing territories instead of only reporting count mismatches. Use `--output json --pretty` when you want machine-readable diagnostics.
+
+### 5. Actual submit
 When the dry run looks clean:
 
 ```bash
@@ -91,28 +109,29 @@ asc release run \
 
 ### 1. Initial app availability does not exist yet
 Symptoms:
-- `asc pricing availability get --app "APP_ID"` reports no availability
-- `asc pricing availability set ...` fails because it only updates existing availability
+- `asc pricing availability view --app "APP_ID"` reports no availability
+- `asc pricing availability edit ...` fails because it only updates existing availability
 
 Check:
 
 ```bash
-asc pricing availability get --app "APP_ID"
+asc pricing availability view --app "APP_ID"
 ```
 
-Bootstrap the first availability record with the web-session flow:
+Bootstrap the first availability record with the public API:
 
 ```bash
-asc web apps availability create \
+asc pricing availability create \
   --app "APP_ID" \
   --territory "USA,GBR" \
+  --available true \
   --available-in-new-territories true
 ```
 
 After bootstrap, use the normal API command for ongoing updates:
 
 ```bash
-asc pricing availability set \
+asc pricing availability edit \
   --app "APP_ID" \
   --territory "USA,GBR" \
   --available true \
@@ -125,6 +144,8 @@ For apps with subscriptions, check readiness explicitly:
 ```bash
 asc validate subscriptions --app "APP_ID" --output table
 ```
+
+If the validator shows `MISSING_METADATA`, read the row-level diagnostics literally. The newest CLI surfaces missing promotional images, review screenshots, pricing or availability coverage, offer readiness, and app/build evidence in one matrix, which is the quickest way to understand why first-review attach still fails.
 
 List current first-review subscription state:
 
@@ -140,6 +161,8 @@ asc web review subscriptions attach-group \
   --group-id "GROUP_ID" \
   --confirm
 ```
+
+If `attach-group` still returns `MISSING_METADATA`, fix the validator-reported prerequisites first. The most common misses are broad pricing coverage and a subscription promotional image.
 
 For one subscription instead of a whole group:
 
@@ -269,6 +292,7 @@ Only set `--demo-account-required=true` when App Review truly needs demo credent
 An app is effectively ready to submit when:
 - `asc submit preflight --app "APP_ID" --version "VERSION"` reports no blocking issues
 - `asc validate --app "APP_ID" --version "VERSION"` is clean or only contains understood non-blocking warnings
+- `asc release stage --confirm` successfully prepared the target version when you want a real pre-submit checkpoint
 - `asc release run ... --dry-run` produces the expected plan
 - the build is `VALID` and attached to the target version
 - metadata, screenshots, and localizations are complete
@@ -305,13 +329,16 @@ asc review submissions-submit --id "SUBMISSION_ID" --confirm
 ## Platform notes
 - Use `--platform MAC_OS`, `TV_OS`, or `VISION_OS` as needed.
 - For macOS, upload the `.pkg` separately, then use the same readiness and submission flow.
-- `asc publish testflight` is still the fastest TestFlight shortcut, but for App Store readiness prefer `asc submit preflight` and `asc release run`.
+- `asc publish testflight` is still the fastest TestFlight shortcut, but for App Store readiness prefer `asc submit preflight`, `asc release stage`, and `asc release run`.
 
 ## Notes
-- `asc release run --dry-run` is the closest thing to a one-command answer for "will this release flow work?"
+- `asc release stage --confirm` is the safest one-command way to prepare a version without submitting it.
+- `asc release run --dry-run` is the closest thing to a one-command answer for "will this full release flow work?"
 - `asc submit preflight` is the fastest first pass.
 - `asc validate` is the deeper API-side checklist for version readiness.
+- `asc validate subscriptions` now exposes much richer per-subscription diagnostics for `MISSING_METADATA` readiness failures.
 - Web-session commands are experimental and should be presented as optional escape hatches when the public API cannot complete the first-time flow.
+- Public `asc pricing availability create` now covers the first app-availability bootstrap case.
 - First-review subscriptions have a concrete CLI attach path; first-review IAP selection still may require the App Store Connect version UI.
 - Game Center can require explicit review-submission item management when components must ride with the app version.
 - If the user asks "why did submission fail?" map the failure back into the three buckets above: API-fixable, web-session-fixable, or manual fallback.

--- a/skills/asc-signing-setup/SKILL.md
+++ b/skills/asc-signing-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asc-signing-setup
-description: Set up bundle IDs, capabilities, signing certificates, and provisioning profiles with the asc cli. Use when onboarding a new app or rotating signing assets.
+description: Set up bundle IDs, capabilities, signing certificates, provisioning profiles, and encrypted signing sync with the asc cli. Use when onboarding a new app, rotating signing assets, or sharing them across a team.
 ---
 
 # asc signing setup
@@ -36,6 +36,29 @@ Use this skill when you need to create or renew signing assets for iOS/macOS app
   - `asc certificates revoke --id "CERT_ID" --confirm`
 - Delete old profiles:
   - `asc profiles delete --id "PROFILE_ID" --confirm`
+
+## Shared team storage with `asc signing sync`
+Use this when you want a lightweight, non-interactive alternative to fastlane match for encrypted git-backed certificate/profile storage.
+
+```bash
+# Push current ASC signing assets into an encrypted git repo
+asc signing sync push \
+  --bundle-id "com.example.app" \
+  --profile-type IOS_APP_STORE \
+  --repo "git@github.com:team/certs.git" \
+  --password "$MATCH_PASSWORD"
+
+# Pull and decrypt them into a local directory
+asc signing sync pull \
+  --repo "git@github.com:team/certs.git" \
+  --password "$MATCH_PASSWORD" \
+  --output-dir "./signing"
+```
+
+Notes:
+- `--password` falls back to `ASC_MATCH_PASSWORD`.
+- The encrypted repo follows a familiar match-style git layout for certs and profiles.
+- `pull` writes files to disk; keychain import or profile installation is a separate step.
 
 ## Notes
 - Always check `--help` for the exact enum values (certificate types, profile types).

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -25,6 +25,9 @@ Check:
 ### 2. Encryption Compliance
 If `usesNonExemptEncryption: true`:
 ```bash
+# If the app should be exempt, patch the local plist helper, rebuild, and re-upload
+asc encryption declarations exempt-declare --plist "./Info.plist"
+
 # List existing declarations
 asc encryption declarations list --app "APP_ID"
 
@@ -42,16 +45,16 @@ asc encryption declarations assign-builds \
   --build "BUILD_ID"
 ```
 
-**Better approach:** Add `ITSAppUsesNonExemptEncryption = NO` to Info.plist and rebuild.
+If the app truly uses only exempt transport encryption, prefer `asc encryption declarations exempt-declare --plist "./Info.plist"` and rebuild instead of creating a declaration that does not match the binary.
 
 ### 3. Content Rights Declaration
 Required for all App Store submissions:
 ```bash
 # Check current status
-asc apps get --id "APP_ID" --output json | jq '.data.attributes.contentRightsDeclaration'
+asc apps content-rights view --app "APP_ID"
 
-# Set if missing
-asc apps update --id "APP_ID" --content-rights "DOES_NOT_USE_THIRD_PARTY_CONTENT"
+# Set it for most apps
+asc apps content-rights edit --app "APP_ID" --uses-third-party-content=false
 ```
 Valid values:
 - `DOES_NOT_USE_THIRD_PARTY_CONTENT`
@@ -60,7 +63,7 @@ Valid values:
 ### 4. Version Metadata
 ```bash
 # Check version details
-asc versions get --version-id "VERSION_ID" --include-build
+asc versions view --version-id "VERSION_ID" --include-build
 
 # Verify copyright is set
 asc versions update --version-id "VERSION_ID" --copyright "2026 Your Company"
@@ -86,7 +89,7 @@ asc apps info list --app "APP_ID"
 asc localizations list --app "APP_ID" --type app-info --app-info "APP_INFO_ID"
 ```
 
-### 8. App Privacy Manual Check
+### 8. App Privacy readiness advisory
 `asc` can warn about App Privacy readiness, but the public App Store Connect API
 cannot verify whether App Privacy is fully published. Before final submission:
 
@@ -113,6 +116,18 @@ confirm App Privacy manually in App Store Connect:
 ```text
 https://appstoreconnect.apple.com/apps/APP_ID/appPrivacy
 ```
+
+### 9. Digital goods readiness (IAPs / subscriptions)
+If the app sells subscriptions or in-app purchases, validate those separately before submit:
+
+```bash
+asc validate iap --app "APP_ID" --output table
+asc validate subscriptions --app "APP_ID" --output table
+```
+
+In `0.45.3+`, `asc validate subscriptions` expands `MISSING_METADATA` into a per-subscription diagnostics matrix. Use it to identify missing review screenshots, promotional images, pricing or availability coverage gaps, offer readiness, and app/build evidence before retrying submit or first-review attach.
+
+Use `--output json --pretty` when you want exact territory gaps in machine-readable form.
 
 ## Submit
 
@@ -184,6 +199,8 @@ asc apps info list --app "APP_ID"
 - `asc submit create` uses the new reviewSubmissions API automatically.
 - `asc submit preflight` can return non-blocking advisories; review them before submitting.
 - App Privacy publish state is not verifiable via the public API.
+- Prefer `asc apps content-rights view/edit` over ad-hoc app JSON inspection.
+- `asc validate subscriptions` now provides much richer per-subscription diagnostics for `MISSING_METADATA` cases.
 - If you use ASC web-session flows, `asc web privacy pull|plan|apply|publish` is the CLI path for App Privacy.
 - If you avoid the experimental web-session commands, confirm App Privacy manually in App Store Connect.
 - Use `--output table` when you want human-readable status.

--- a/skills/asc-xcode-build/SKILL.md
+++ b/skills/asc-xcode-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asc-xcode-build
-description: Build, archive, and export iOS/macOS apps with xcodebuild before uploading to App Store Connect. Use when you need to create an IPA or PKG for upload.
+description: Build, archive, export, and manage Xcode version/build numbers with asc and xcodebuild before uploading to App Store Connect. Use when you need to create an IPA or PKG for upload.
 ---
 
 # Xcode Build and Export
@@ -10,6 +10,21 @@ Use this skill when you need to build an app from source and prepare it for uplo
 ## Preconditions
 - Xcode installed and command line tools configured
 - Valid signing identity and provisioning profiles (or automatic signing enabled)
+
+## Manage version and build numbers with `asc`
+Before archiving, prefer `asc xcode version ...` over manual `pbxproj` edits when you need to inspect or bump app versions.
+
+```bash
+asc xcode version view
+asc xcode version edit --version "1.3.0" --build-number "42"
+asc xcode version bump --type build
+asc xcode version bump --type patch
+```
+
+Notes:
+- Use `--project-dir "./MyApp"` when you are not running from the project root.
+- Use `--target "App"` for deterministic reads in multi-target projects.
+- These commands support both legacy `agvtool` projects and modern `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` setups.
 
 ## iOS Build Flow
 
@@ -109,7 +124,7 @@ macOS requires ICNS format icons with all sizes:
 - 16x16, 32x32, 128x128, 256x256, 512x512 (1x and 2x)
 
 ### CFBundleVersion too low
-The build number must be higher than any previously uploaded build. Increment `CURRENT_PROJECT_VERSION` and rebuild.
+The build number must be higher than any previously uploaded build. Increment it with `asc xcode version bump --type build` (or `asc xcode version edit --build-number "NEXT"`) and rebuild.
 
 ## Notes
 - Always clean before archive for release builds


### PR DESCRIPTION
## Summary
- reframe the release and submission docs around `asc submit preflight`, `asc release stage`, first-time monetization blockers, and App Privacy readiness
- refresh skill examples to match current canonical command surfaces, including `view`/`edit` verbs, pricing availability bootstrap, content-rights helpers, Xcode version commands, signing sync, and legacy metadata import flows
- sync release-adjacent docs with recent CLI behavior such as `asc validate subscriptions` diagnostics, Koubou `0.18.0`, and updated localization argument names

## Test plan
- [ ] Not run (docs-only changes)