### PR TITLE
[codex] refresh skill docs for current asc command surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Agent-first screenshot pipeline using xcodebuild/simctl, AXe, JSON plans, `asc s
 - You want AXe-based UI driving before capture
 - You need a staged pipeline (capture -> frame -> upload)
 - You need to discover supported frame devices (`asc screenshots list-frame-devices`)
-- You want pinned Koubou guidance for deterministic framing (`koubou==0.18.0`)
+- You want pinned Koubou guidance for deterministic framing (`koubou==0.18.1`)
 
 **Example:**
 

--- a/skills/asc-app-create-ui/SKILL.md
+++ b/skills/asc-app-create-ui/SKILL.md
@@ -94,14 +94,13 @@ asc apps list --bundle-id "com.example.app" --output json
 ```bash
 asc app-setup info set --app "APP_ID" --primary-locale "en-US"
 asc app-setup categories set --app "APP_ID" --primary GAMES
-asc pricing availability create \
+asc web apps availability create \
   --app "APP_ID" \
   --territory "USA,GBR" \
-  --available true \
   --available-in-new-territories true
 ```
 
-If app availability already exists, switch to `asc pricing availability edit --app "APP_ID" ...` for later territory changes.
+Use the experimental web flow above only for the first availability bootstrap. If app availability already exists, switch to `asc pricing availability edit --app "APP_ID" ...` for later territory changes.
 
 ## Known UI Automation Issues
 

--- a/skills/asc-build-lifecycle/SKILL.md
+++ b/skills/asc-build-lifecycle/SKILL.md
@@ -9,12 +9,14 @@ Use this skill to manage build state, processing, and retention.
 
 ## Find the right build
 - Latest build:
-  - `asc builds latest --app "APP_ID" --version "1.2.3" --platform IOS`
+  - `asc builds info --app "APP_ID" --latest --version "1.2.3" --platform IOS`
+- Next safe build number:
+  - `asc builds next-build-number --app "APP_ID" --version "1.2.3" --platform IOS`
 - Recent builds:
   - `asc builds list --app "APP_ID" --sort -uploadedDate --limit 10`
 
 ## Inspect processing state
-- `asc builds info --build "BUILD_ID"`
+- `asc builds info --build-id "BUILD_ID"`
 
 ## Distribution flows
 - Prefer end-to-end:
@@ -27,7 +29,7 @@ Use this skill to manage build state, processing, and retention.
 - Apply expiration:
   - `asc builds expire-all --app "APP_ID" --older-than 90d --confirm`
 - Single build:
-  - `asc builds expire --build "BUILD_ID" --confirm`
+  - `asc builds expire --build-id "BUILD_ID" --confirm`
 
 ## Notes
 - `asc builds upload` prepares upload operations only; use `asc publish` for end-to-end flows.

--- a/skills/asc-cli-usage/SKILL.md
+++ b/skills/asc-cli-usage/SKILL.md
@@ -13,7 +13,7 @@ Use this skill when you need to run or design `asc` commands for App Store Conne
   - `asc builds --help`
   - `asc builds list --help`
 
-## Canonical verbs (0.45.x+)
+## Canonical verbs (current asc)
 - Prefer `view` over legacy `get` aliases for read-only commands in docs and automation.
   - `asc apps view --id "APP_ID"`
   - `asc versions view --version-id "VERSION_ID"`

--- a/skills/asc-crash-triage/SKILL.md
+++ b/skills/asc-crash-triage/SKILL.md
@@ -34,7 +34,7 @@ List recent feedback (newest first):
 
 ## Performance diagnostics (hangs, disk writes, launches)
 
-Requires a build ID. Resolve via `asc builds latest --app "APP_ID" --platform IOS` or `asc builds list --app "APP_ID" --sort -uploadedDate --limit 5`.
+Requires a build ID. Resolve via `asc builds info --app "APP_ID" --latest --platform IOS` or `asc builds list --app "APP_ID" --sort -uploadedDate --limit 5`.
 
 - List diagnostic signatures: `asc performance diagnostics list --build "BUILD_ID"`
 - Filter by type: `asc performance diagnostics list --build "BUILD_ID" --diagnostic-type "HANGS"`
@@ -45,7 +45,7 @@ Requires a build ID. Resolve via `asc builds latest --app "APP_ID" --platform IO
 ## Resolving IDs
 
 - App ID from name: `asc apps list --name "AppName"` or `asc apps list --bundle-id "com.example.app"`
-- Latest build ID: `asc builds latest --app "APP_ID" --platform IOS`
+- Latest build ID: `asc builds info --app "APP_ID" --latest --platform IOS`
 - Recent builds: `asc builds list --app "APP_ID" --sort -uploadedDate --limit 5`
 - Set default: `export ASC_APP_ID="APP_ID"`
 

--- a/skills/asc-id-resolver/SKILL.md
+++ b/skills/asc-id-resolver/SKILL.md
@@ -18,7 +18,7 @@ Use this skill to map names to IDs needed by other commands.
 
 ## Build ID
 - Latest build:
-  - `asc builds latest --app "APP_ID" --version "1.2.3" --platform IOS`
+  - `asc builds info --app "APP_ID" --latest --version "1.2.3" --platform IOS`
 - Recent builds:
   - `asc builds list --app "APP_ID" --sort -uploadedDate --limit 5`
 

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -22,8 +22,8 @@ When using this skill, answer readiness questions in this order:
 4. What exact command should run next?
 
 Group blockers like this:
-- API-fixable: build validity, metadata, screenshots, review details, content rights, encryption, version/build attachment, app availability bootstrap, IAP readiness, Game Center version and review-submission setup.
-- Web-session-fixable: first-review subscription attachment, App Privacy publish state.
+- API-fixable: build validity, metadata, screenshots, review details, content rights, encryption, version/build attachment, IAP readiness, Game Center version and review-submission setup.
+- Web-session-fixable: initial app availability bootstrap, first-review subscription attachment, App Privacy publish state.
 - Manual fallback: first-time IAP selection from the app-version screen when no CLI attach flow exists, or any flow the user does not want to run through experimental web-session commands.
 
 ## Canonical path
@@ -89,7 +89,7 @@ asc validate iap --app "APP_ID" --output table
 asc validate subscriptions --app "APP_ID" --output table
 ```
 
-In `0.45.3+`, `asc validate subscriptions` expands `MISSING_METADATA` into per-subscription diagnostics. Use it to pinpoint missing review screenshots, promotional images, pricing or availability coverage, offer readiness, and app/build evidence before you retry submission or `attach-group`.
+In current asc, `asc validate subscriptions` expands `MISSING_METADATA` into per-subscription diagnostics. Use it to pinpoint missing review screenshots, promotional images, pricing or availability coverage, offer readiness, and app/build evidence before you retry submission or `attach-group`.
 
 When territory coverage is wrong, the newest diagnostics name the exact missing territories instead of only reporting count mismatches. Use `--output json --pretty` when you want machine-readable diagnostics.
 
@@ -118,17 +118,16 @@ Check:
 asc pricing availability view --app "APP_ID"
 ```
 
-Bootstrap the first availability record with the public API:
+Bootstrap the first availability record with the experimental web-session flow:
 
 ```bash
-asc pricing availability create \
+asc web apps availability create \
   --app "APP_ID" \
   --territory "USA,GBR" \
-  --available true \
   --available-in-new-territories true
 ```
 
-After bootstrap, use the normal API command for ongoing updates:
+After bootstrap, use the normal public API command for ongoing updates:
 
 ```bash
 asc pricing availability edit \
@@ -338,7 +337,7 @@ asc review submissions-submit --id "SUBMISSION_ID" --confirm
 - `asc validate` is the deeper API-side checklist for version readiness.
 - `asc validate subscriptions` now exposes much richer per-subscription diagnostics for `MISSING_METADATA` readiness failures.
 - Web-session commands are experimental and should be presented as optional escape hatches when the public API cannot complete the first-time flow.
-- Public `asc pricing availability create` now covers the first app-availability bootstrap case.
+- First-time app-availability bootstrap now goes through the experimental `asc web apps availability create` flow or App Store Connect itself.
 - First-review subscriptions have a concrete CLI attach path; first-review IAP selection still may require the App Store Connect version UI.
 - Game Center can require explicit review-submission item management when components must ride with the app version.
 - If the user asks "why did submission fail?" map the failure back into the three buckets above: API-fixable, web-session-fixable, or manual fallback.

--- a/skills/asc-shots-pipeline/SKILL.md
+++ b/skills/asc-shots-pipeline/SKILL.md
@@ -11,7 +11,7 @@ Use this skill for agent-driven screenshot workflows where the app is built and 
 - Implemented now: build/run, AXe plan capture, frame composition, and upload.
 - Device discovery is built-in via `asc screenshots list-frame-devices`.
 - Local screenshot automation commands are experimental in asc cli.
-- Framing is pinned to Koubou `0.18.0` for deterministic output.
+- Framing is pinned to Koubou `0.18.1` for deterministic output.
 - Feedback/issues: https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/new/choose
 
 ## Defaults
@@ -113,12 +113,12 @@ Minimal `.asc/screenshots.json` example:
 
 ## 4) Frame screenshots with `asc screenshots frame`
 
-asc cli pins framing to Koubou `0.18.0`.
+asc cli pins framing to Koubou `0.18.1`.
 Install and verify before running framing steps:
 
 ```bash
-pip install koubou==0.18.0
-kou --version  # expect 0.18.0
+pip install koubou==0.18.1
+kou --version  # expect 0.18.1
 # If Koubou reports missing device frames, run once with network access:
 kou setup-frames
 ```
@@ -182,7 +182,7 @@ asc screenshots list --version-localization "LOC_ID" --output table
 - Ensure screenshot files exist before upload.
 - Use explicit long flags (`--app`, `--output`, `--version-localization`, etc.).
 - Treat screenshot-local automation as experimental and call it out in user-facing handoff notes.
-- If framing fails with a version error, re-install pinned Koubou: `pip install koubou==0.18.0`.
+- If framing fails with a version error, re-install pinned Koubou: `pip install koubou==0.18.1`.
 - If framing fails because device frames are missing, run `kou setup-frames` once with network access.
 
 ## 6) Multi-locale capture (optional)

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -125,7 +125,7 @@ asc validate iap --app "APP_ID" --output table
 asc validate subscriptions --app "APP_ID" --output table
 ```
 
-In `0.45.3+`, `asc validate subscriptions` expands `MISSING_METADATA` into a per-subscription diagnostics matrix. Use it to identify missing review screenshots, promotional images, pricing or availability coverage gaps, offer readiness, and app/build evidence before retrying submit or first-review attach.
+In current asc, `asc validate subscriptions` expands `MISSING_METADATA` into a per-subscription diagnostics matrix. Use it to identify missing review screenshots, promotional images, pricing or availability coverage gaps, offer readiness, and app/build evidence before retrying submit or first-review attach.
 
 Use `--output json --pretty` when you want exact territory gaps in machine-readable form.
 

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -16,7 +16,7 @@ Use this skill to reduce review submission failures and monitor status.
 
 ### 1. Verify Build Status
 ```bash
-asc builds info --build "BUILD_ID"
+asc builds info --build-id "BUILD_ID"
 ```
 Check:
 - `processingState` is `VALID`

--- a/skills/asc-testflight-orchestration/SKILL.md
+++ b/skills/asc-testflight-orchestration/SKILL.md
@@ -22,13 +22,13 @@ Use this skill when managing TestFlight testers, groups, and build distribution.
   - `asc testflight testers invite --app "APP_ID" --email "tester@example.com"`
 
 ## Distribute builds
-- `asc builds add-groups --build "BUILD_ID" --group "GROUP_ID"`
+- `asc builds add-groups --build-id "BUILD_ID" --group "GROUP_ID"`
 - Remove from group:
-  - `asc builds remove-groups --build "BUILD_ID" --group "GROUP_ID" --confirm`
+  - `asc builds remove-groups --build-id "BUILD_ID" --group "GROUP_ID" --confirm`
 
 ## What to Test notes
-- `asc builds test-notes create --build "BUILD_ID" --locale "en-US" --whats-new "Test instructions"`
-- `asc builds test-notes update --id "LOCALIZATION_ID" --whats-new "Updated notes"`
+- `asc builds test-notes create --build-id "BUILD_ID" --locale "en-US" --whats-new "Test instructions"`
+- `asc builds test-notes update --localization-id "LOCALIZATION_ID" --whats-new "Updated notes"`
 
 ## Notes
 - Use `--paginate` on large groups/tester lists.

--- a/skills/asc-workflow/SKILL.md
+++ b/skills/asc-workflow/SKILL.md
@@ -181,7 +181,7 @@ Sub-workflow call step (`"workflow": "...", "with": {...}`):
         {
           "name": "add_build_to_group",
           "if": "BUILD_ID",
-          "run": "asc builds add-groups --build $BUILD_ID --group $GROUP_ID"
+          "run": "asc builds add-groups --build-id $BUILD_ID --group $GROUP_ID"
         },
         {
           "name": "notify",

--- a/skills/asc-xcode-build/SKILL.md
+++ b/skills/asc-xcode-build/SKILL.md
@@ -124,7 +124,7 @@ macOS requires ICNS format icons with all sizes:
 - 16x16, 32x32, 128x128, 256x256, 512x512 (1x and 2x)
 
 ### CFBundleVersion too low
-The build number must be higher than any previously uploaded build. Increment it with `asc xcode version bump --type build` (or `asc xcode version edit --build-number "NEXT"`) and rebuild.
+The build number must be higher than any previously uploaded build. Increment it with `asc xcode version bump --type build`, or resolve a remote-safe number with `asc builds next-build-number --app "APP_ID" --version "2.2.0" --platform IOS` and then apply it with `asc xcode version edit --build-number "NEXT_BUILD"` before rebuilding.
 
 ## Notes
 - Always clean before archive for release builds


### PR DESCRIPTION
## What changed
This expands the original build-command refresh into a broader tracked-doc audit against the current `asc` CLI surface.

The PR now updates 12 tracked files across README and skills docs.

Main fixes:
- Replaced deprecated `asc builds latest` guidance with `asc builds info --latest` or `asc builds next-build-number`, depending on intent
- Switched current `builds` selector examples from `--build` to canonical `--build-id` where the latest CLI uses the newer selector form
- Updated `asc builds test-notes update` examples to `--localization-id`
- Replaced outdated app-availability bootstrap guidance from public `asc pricing availability create` to the current experimental `asc web apps availability create` flow
- Refreshed screenshot framing guidance from `koubou==0.18.0` to `koubou==0.18.1`
- Reworded a few version-anchored notes so the docs describe the current CLI rather than an older refresh point
- Replaced stale Xcode build-number guidance that suggested `--build-number "NEXT"` with the current `asc builds next-build-number` flow

## Why
The skills repo had already been partially refreshed, but a harder repo-wide audit still found drift in:
- build lookup and build selector examples
- first-time app availability bootstrap guidance
- screenshot framing version pinning
- a few older version-scoped notes and examples

I used the latest upstream `App-Store-Connect-CLI` `main` plus the locally installed `asc 0.47.0` as the current source of truth.

## Impact
Users following these skills should now get current guidance for:
- latest-build and next-build-number resolution
- TestFlight build distribution selectors
- first-time app availability setup
- screenshot framing setup
- Xcode build-number workflows
- current release-flow triage buckets for API vs web-session fixes

## Validation
- Checked current command help for representative surfaces across the audited families, including:
  - `asc builds info`
  - `asc builds next-build-number`
  - `asc builds expire`
  - `asc builds add-groups`
  - `asc builds remove-groups`
  - `asc builds test-notes create`
  - `asc builds test-notes update`
  - `asc pricing availability`
  - `asc web apps availability create`
  - `asc screenshots capture`
  - `asc screenshots frame`
  - `asc screenshots run`
  - `asc screenshots upload`
  - `asc xcode archive`
  - `asc xcode export`
  - `asc xcode version view|edit|bump`
  - `asc metadata validate`
  - `asc migrate export|import|validate`
  - `asc build-localizations create`
  - `asc versions attach-build`
  - `asc subscriptions review`
  - `asc web review subscriptions`
- Ran `git diff --check`
- Left unrelated untracked draft blog posts out of the PR

## Notes
I also audited the two local draft blog files in the workspace. One of them (`blog-post-xcode-cloud-local-builds.md`) needed command updates and was patched locally, but it remains untracked and is intentionally not included in this PR.
