### PR TITLE
Migrate repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # asc cli skills
 
-A collection of Agent Skills for shipping with the [asc cli](https://github.com/rudrankriyam/App-Store-Connect-CLI) (`asc`). These skills are designed for zero-friction automation around builds, TestFlight, metadata, submissions, and signing.
+A collection of Agent Skills for shipping with the [asc cli](https://github.com/rorkai/App-Store-Connect-CLI) (`asc`). These skills are designed for zero-friction automation around builds, TestFlight, metadata, submissions, and signing.
 
 This is a community-maintained, unofficial skill pack and is not affiliated with Apple.
 
@@ -11,7 +11,7 @@ Skills follow the Agent Skills format.
 Install this skill pack:
 
 ```bash
-npx skills add rudrankriyam/app-store-connect-cli-skills
+npx skills add rorkai/app-store-connect-cli-skills
 ```
 
 ## Available Skills

--- a/skills/asc-shots-pipeline/SKILL.md
+++ b/skills/asc-shots-pipeline/SKILL.md
@@ -12,7 +12,7 @@ Use this skill for agent-driven screenshot workflows where the app is built and 
 - Device discovery is built-in via `asc screenshots list-frame-devices`.
 - Local screenshot automation commands are experimental in asc cli.
 - Framing is pinned to Koubou `0.18.1` for deterministic output.
-- Feedback/issues: https://github.com/rudrankriyam/App-Store-Connect-CLI/issues/new/choose
+- Feedback/issues: https://github.com/rorkai/App-Store-Connect-CLI/issues/new/choose
 
 ## Defaults
 - Settings file: `.asc/shots.settings.json`


### PR DESCRIPTION
## Summary
- migrate CLI and skills repo references from `rudrankriyam` to `rorkai`
- update install instructions and feedback links

## Testing
- not run (docs/link update only)