### PR TITLE
[codex] Update stale asc skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Build my iOS app, capture the home and settings screens in the simulator, frame 
 
 ### asc-release-flow
 
-Readiness-first App Store submission guidance, including `asc release stage`, `asc submit preflight`, and first-time release blockers.
+Readiness-first App Store submission guidance, including `asc validate`, `asc release stage`, `asc review submit`, and first-time release blockers.
 
 **Use when:**
 - You want the quickest answer to "can I submit this app now?"

--- a/skills/asc-metadata-sync/SKILL.md
+++ b/skills/asc-metadata-sync/SKILL.md
@@ -1,148 +1,155 @@
 ---
 name: asc-metadata-sync
-description: Sync and validate App Store metadata and localizations with asc, including legacy metadata format migration. Use when updating metadata or translations.
+description: Sync, validate, and apply App Store metadata with the current asc canonical metadata workflow. Use when updating metadata, localizations, keywords, or migrating legacy fastlane metadata.
 ---
 
 # asc metadata sync
 
-Use this skill to keep local metadata in sync with App Store Connect.
+Use this skill to keep App Store metadata in sync with App Store Connect. Prefer the canonical `asc metadata` workflow for app-info and version localization fields. Use the lower-level `asc localizations` and `asc migrate` commands only when the user specifically needs `.strings` files or legacy fastlane-format metadata.
 
-## Two Types of Localizations
+## Current canonical workflow
 
-### 1. Version Localizations (per-release)
-Fields: `description`, `keywords`, `whatsNew`, `supportUrl`, `marketingUrl`, `promotionalText`
+### 1. Pull canonical metadata
 
 ```bash
-# List version localizations
-asc localizations list --version "VERSION_ID"
+asc metadata pull --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
+```
 
-# Download
+If the app has multiple app-info records, resolve the app-info ID first and pass it explicitly:
+
+```bash
+asc apps info list --app "APP_ID" --output table
+asc metadata pull --app "APP_ID" --app-info "APP_INFO_ID" --version "1.2.3" --platform IOS --dir "./metadata"
+```
+
+### 2. Edit local files
+
+Canonical files are written under:
+
+- `metadata/app-info/<locale>.json` for app-level fields: `name`, `subtitle`, `privacyPolicyUrl`, `privacyChoicesUrl`, `privacyPolicyText`
+- `metadata/version/<version>/<locale>.json` for version fields: `description`, `keywords`, `marketingUrl`, `promotionalText`, `supportUrl`, `whatsNew`
+
+Copyright is not a localization field. Manage it with:
+
+```bash
+asc versions update --version-id "VERSION_ID" --copyright "2026 Your Company"
+```
+
+### 3. Validate before upload
+
+```bash
+asc metadata validate --dir "./metadata" --output table
+```
+
+For subscription apps, include the extra Terms of Use / EULA heuristic:
+
+```bash
+asc metadata validate --dir "./metadata" --subscription-app --output table
+```
+
+### 4. Preview and apply
+
+Run a dry run first:
+
+```bash
+asc metadata push --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata" --dry-run --output table
+```
+
+Apply after the plan looks correct:
+
+```bash
+asc metadata push --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
+```
+
+Use `asc metadata apply` when the user wants the apply-named command shape for the same canonical files:
+
+```bash
+asc metadata apply --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata" --dry-run
+asc metadata apply --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
+```
+
+## Keyword-only workflow
+
+Use this when only the version-localization `keywords` field should change:
+
+```bash
+asc metadata keywords diff --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
+asc metadata keywords apply --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata" --confirm
+```
+
+For importing keyword research:
+
+```bash
+asc metadata keywords import --dir "./metadata" --version "1.2.3" --locale "en-US" --input "./keywords.csv"
+asc metadata keywords sync --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata" --input "./keywords.csv"
+```
+
+## Quick field updates
+
+For one-off version-localization edits, pass an explicit version selector. Use `--version-id` for deterministic updates when you already have it, or `--version` plus `--platform` when working from a version string.
+
+```bash
+asc apps info edit --app "APP_ID" --version-id "VERSION_ID" --locale "en-US" --whats-new "Bug fixes and improvements"
+asc apps info edit --app "APP_ID" --version "1.2.3" --platform IOS --locale "en-US" --description "Your app description here"
+asc apps info edit --app "APP_ID" --version "1.2.3" --platform IOS --locale "en-US" --keywords "keyword1,keyword2,keyword3"
+asc apps info edit --app "APP_ID" --version "1.2.3" --platform IOS --locale "en-US" --support-url "https://support.example.com"
+```
+
+For app-info fields, prefer the post-create setup command:
+
+```bash
+asc app-setup info set --app "APP_ID" --primary-locale "en-US" --privacy-policy-url "https://example.com/privacy"
+asc app-setup info set --app "APP_ID" --locale "en-US" --name "Your App Name" --subtitle "Your subtitle"
+```
+
+## Lower-level localization files
+
+Use `.strings` files when the user specifically wants import/export files instead of canonical JSON:
+
+```bash
+asc localizations list --version "VERSION_ID" --output table
 asc localizations download --version "VERSION_ID" --path "./localizations"
-
-# Upload from .strings files
+asc localizations upload --version "VERSION_ID" --path "./localizations" --dry-run
 asc localizations upload --version "VERSION_ID" --path "./localizations"
 ```
 
-### 2. App Info Localizations (app-level)
-Fields: `name`, `subtitle`, `privacyPolicyUrl`, `privacyChoicesUrl`, `privacyPolicyText`
+For app-info localizations:
 
 ```bash
-# First, find the app info ID
-asc apps info list --app "APP_ID"
-
-# List app info localizations
-asc localizations list --app "APP_ID" --type app-info --app-info "APP_INFO_ID"
-
-# Upload app info localizations
+asc apps info list --app "APP_ID" --output table
+asc localizations list --app "APP_ID" --type app-info --app-info "APP_INFO_ID" --output table
+asc localizations download --app "APP_ID" --type app-info --app-info "APP_INFO_ID" --path "./app-info-localizations"
+asc localizations upload --app "APP_ID" --type app-info --app-info "APP_INFO_ID" --path "./app-info-localizations" --dry-run
 asc localizations upload --app "APP_ID" --type app-info --app-info "APP_INFO_ID" --path "./app-info-localizations"
 ```
 
-**Note:** If you get "multiple app infos found", you must specify `--app-info` with the correct ID.
+## Legacy fastlane metadata
 
-## Legacy Fastlane Metadata Workflow
+Use this only for existing fastlane-format trees:
 
-### Export current state
 ```bash
 asc migrate export --app "APP_ID" --version-id "VERSION_ID" --output-dir "./fastlane"
-```
-
-### Validate local files
-```bash
 asc migrate validate --fastlane-dir "./fastlane"
-```
-This checks character limits and required fields.
-
-### Import updates
-```bash
 asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir "./fastlane" --dry-run
 asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir "./fastlane"
 ```
 
-## Quick Field Updates
-
-### Version-specific fields
-```bash
-# What's New
-asc apps info edit --app "APP_ID" --locale "en-US" --whats-new "Bug fixes and improvements"
-
-# Description
-asc apps info edit --app "APP_ID" --locale "en-US" --description "Your app description here"
-
-# Keywords
-asc apps info edit --app "APP_ID" --locale "en-US" --keywords "keyword1,keyword2,keyword3"
-
-# Support URL
-asc apps info edit --app "APP_ID" --locale "en-US" --support-url "https://support.example.com"
-```
-
-### Version metadata
-```bash
-# Copyright
-asc versions update --version-id "VERSION_ID" --copyright "2026 Your Company"
-
-# Release type
-asc versions update --version-id "VERSION_ID" --release-type AFTER_APPROVAL
-```
-
-### TestFlight notes
-```bash
-asc build-localizations create --build "BUILD_ID" --locale "en-US" --whats-new "TestFlight notes here"
-```
-
-## .strings File Format
-
-For bulk updates, use .strings files:
-
-```
-// en-US.strings
-"description" = "Your app description";
-"keywords" = "keyword1,keyword2,keyword3";
-"whatsNew" = "What's new in this version";
-"supportUrl" = "https://support.example.com";
-```
-
-For app-info type:
-```
-// en-US.strings (app-info type)
-"privacyPolicyUrl" = "https://example.com/privacy";
-"name" = "Your App Name";
-"subtitle" = "Your subtitle";
-```
-
-## Multi-Language Workflow
-
-1. Export all localizations:
-```bash
-asc localizations download --version "VERSION_ID" --path "./localizations"
-```
-
-2. Translate the .strings files (or use translation service)
-
-3. Upload all at once:
-```bash
-asc localizations upload --version "VERSION_ID" --path "./localizations"
-```
-
-4. Verify:
-```bash
-asc localizations list --version "VERSION_ID" --output table
-```
-
-## Character Limits
+## Character limits
 
 | Field | Limit |
 |-------|-------|
 | Name | 30 |
 | Subtitle | 30 |
-| Keywords | 100 (comma-separated) |
+| Keywords | 100 comma-separated characters |
 | Description | 4000 |
 | What's New | 4000 |
 | Promotional Text | 170 |
 
-Use `asc metadata validate --dir "./metadata"` for canonical metadata trees.
-Use `asc migrate validate --fastlane-dir "./fastlane"` for legacy fastlane-format metadata.
+## Agent behavior
 
-## Notes
-- Version localizations and app info localizations are different; use the right command and `--type` flag.
-- Use `asc localizations list` to confirm available locales and IDs.
-- Privacy Policy URL is in app info localizations, not version localizations.
+- Start with `asc metadata pull` unless the user specifically asks for `.strings` or fastlane metadata.
+- Always run `asc metadata validate` before remote writes.
+- Preview remote changes with `--dry-run` when the command supports it.
+- For quick edits, always pass `--version-id` or `--version` plus `--platform`; do not rely on ambiguous latest-version behavior.
+- Keep app-info fields and version fields separate.
+- Use `--output table` for human verification and JSON for automation.

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -1,44 +1,70 @@
 ---
 name: asc-release-flow
-description: Determine whether an app is ready to submit, then drive the App Store release flow with asc, including first-time submission fixes for availability, in-app purchases, subscriptions, Game Center, and App Privacy.
+description: Determine whether an app is ready to submit, then drive the current App Store release flow with asc, including validation, staging, review submission, first-time availability, subscriptions, IAP, Game Center, and App Privacy checks.
 ---
 
 # Release flow (readiness-first)
 
-Use this skill when the real question is "Can my app be ready to submit?" and then guide the user through the shortest path to a clean App Store submission, especially for first-time releases.
+Use this skill when the question is "Can my app be submitted now?" or when the user wants to prepare and submit an App Store version with the current `asc` command surface.
 
 ## Preconditions
-- Ensure credentials are set (`asc auth login` or `ASC_*` env vars).
-- Resolve app ID, version string, and build ID up front.
-- For lower-level or first-time flows, also be ready to resolve `VERSION_ID`, `SUBMISSION_ID`, `DETAIL_ID`, `GROUP_ID`, `SUB_ID`, `IAP_ID`, and related resource IDs. Use `asc-id-resolver` when needed.
-- Have a metadata directory ready if you plan to use `asc release stage` or `asc release run`.
-- If you use experimental web-session commands, use a user-owned Apple Account session and treat those commands as optional escape hatches, not the default path.
 
-## How to answer
-When using this skill, answer readiness questions in this order:
-1. Is the app ready right now, or not yet?
-2. What are the blocking issues?
-3. Which blockers are API-fixable vs web-session-fixable?
-4. What exact command should run next?
+- Resolve `APP_ID`, version string, `VERSION_ID` when needed, and `BUILD_ID` up front.
+- Ensure auth is configured with `asc auth login` or `ASC_*` environment variables.
+- Have canonical metadata in `./metadata` when using metadata-driven staging.
+- Treat `asc web ...` commands as optional experimental escape hatches for flows not covered by the public API.
 
-Group blockers like this:
-- API-fixable: build validity, metadata, screenshots, review details, content rights, encryption, version/build attachment, IAP readiness, Game Center version and review-submission setup.
+## Answer order
+
+1. Say whether the app is ready right now.
+2. Name the blocking issues.
+3. Separate public-API fixes from web-session or manual fixes.
+4. Give the next exact command to run.
+
+Blockers usually fall into:
+
+- API-fixable: build validity, metadata, screenshots, review details, content rights, encryption, version/build attachment, IAP readiness, Game Center version and review-submission items.
 - Web-session-fixable: initial app availability bootstrap, first-review subscription attachment, App Privacy publish state.
-- Manual fallback: first-time IAP selection from the app-version screen when no CLI attach flow exists, or any flow the user does not want to run through experimental web-session commands.
+- Manual fallback: first-time IAP selection on the app-version page when no CLI attach flow exists, or any flow the user does not want to run through experimental web-session commands.
 
-## Canonical path
+## Canonical current path
 
-### 1. Fast readiness check
-Run this first when the user wants the quickest answer to "can I submit now?":
+### 1. Readiness check
+
+Use `asc validate`; the old submit-preflight shortcut is not part of the current CLI.
 
 ```bash
-asc submit preflight --app "APP_ID" --version "1.2.3" --platform IOS
+asc validate --app "APP_ID" --version "1.2.3" --platform IOS --output table
 ```
 
-This is the fastest high-signal readiness check and prints fix guidance without mutating anything.
+Use strict mode when warnings should block automation:
 
-### 2. Real staging pass without submit
-Run this when the user wants the version prepared in App Store Connect but wants a manual checkpoint before creating a review submission:
+```bash
+asc validate --app "APP_ID" --version "1.2.3" --platform IOS --strict --output table
+```
+
+For apps selling digital goods, run the product readiness checks too:
+
+```bash
+asc validate iap --app "APP_ID" --output table
+asc validate subscriptions --app "APP_ID" --output table
+```
+
+### 2. Stage without submitting
+
+Use `asc release stage` when the user wants to prepare the version, apply/copy metadata, attach the build, and validate, while stopping before review submission.
+
+```bash
+asc release stage \
+  --app "APP_ID" \
+  --version "1.2.3" \
+  --build "BUILD_ID" \
+  --metadata-dir "./metadata/version/1.2.3" \
+  --dry-run \
+  --output table
+```
+
+Apply the staging mutations after the plan looks correct:
 
 ```bash
 asc release stage \
@@ -49,68 +75,47 @@ asc release stage \
   --confirm
 ```
 
-Use `--copy-metadata-from "1.2.2"` instead of `--metadata-dir` when you want to carry metadata forward from an existing version. `asc release stage` requires exactly one metadata source and stops before submit.
+Use `--copy-metadata-from "1.2.2"` instead of `--metadata-dir` when carrying metadata forward from an existing version.
 
-### 3. Full-pipeline dry run
-Run this when the user wants one command that approximates the whole release path:
+### 3. Submit an already prepared version
+
+Use `asc review submit` for explicit App Store review submission. It wraps build attachment plus review submission creation.
 
 ```bash
-asc release run \
-  --app "APP_ID" \
-  --version "1.2.3" \
-  --build "BUILD_ID" \
-  --metadata-dir "./metadata/version/1.2.3" \
-  --dry-run \
-  --output table
+asc review submit --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --dry-run --output table
+asc review submit --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --confirm
 ```
 
-This is the best single-command rehearsal for:
-1. ensuring or creating the version
-2. applying metadata and localizations
-3. attaching the build
-4. running readiness checks
-5. confirming the submission path is coherent
+Use `--version-id "VERSION_ID"` instead of `--version` when you already resolved the exact version ID.
 
-Add `--strict-validate` when you want warnings treated as blockers.
+### 4. One-command upload and submit
 
-### 4. Deep API readiness audit
-Run this when the user needs a fuller version-level checklist than `submit preflight`:
+Use `asc publish appstore` when upload/build/local-build and submission should be one high-level flow.
 
 ```bash
-asc validate --app "APP_ID" --version "1.2.3" --platform IOS --output table
+asc publish appstore --app "APP_ID" --ipa "./App.ipa" --version "1.2.3" --submit --dry-run --output table
+asc publish appstore --app "APP_ID" --ipa "./App.ipa" --version "1.2.3" --submit --confirm
 ```
 
-Prefer the version string form here so it stays aligned with `asc submit preflight` and `asc release run`. Switch to `VERSION_ID` only for lower-level commands that explicitly require it.
+Add `--wait` when the command should wait for build processing before attaching/submitting.
 
-If the app sells digital goods, also run:
-
-```bash
-asc validate iap --app "APP_ID" --output table
-asc validate subscriptions --app "APP_ID" --output table
-```
-
-In current asc, `asc validate subscriptions` expands `MISSING_METADATA` into per-subscription diagnostics. Use it to pinpoint missing review screenshots, promotional images, pricing or availability coverage, offer readiness, and app/build evidence before you retry submission or `attach-group`.
-
-When territory coverage is wrong, the newest diagnostics name the exact missing territories instead of only reporting count mismatches. Use `--output json --pretty` when you want machine-readable diagnostics.
-
-### 5. Actual submit
-When the dry run looks clean:
+### 5. Monitor and cancel
 
 ```bash
-asc release run \
-  --app "APP_ID" \
-  --version "1.2.3" \
-  --build "BUILD_ID" \
-  --metadata-dir "./metadata/version/1.2.3" \
-  --confirm
+asc status --app "APP_ID"
+asc submit status --version-id "VERSION_ID"
+asc submit status --id "SUBMISSION_ID"
+asc submit cancel --id "SUBMISSION_ID" --confirm
 ```
 
 ## First-time submission blockers
 
-### 1. Initial app availability does not exist yet
+### Initial app availability does not exist
+
 Symptoms:
-- `asc pricing availability view --app "APP_ID"` reports no availability
-- `asc pricing availability edit ...` fails because it only updates existing availability
+
+- `asc pricing availability view --app "APP_ID"` reports no availability.
+- `asc pricing availability edit ...` cannot update because there is no existing availability record.
 
 Check:
 
@@ -127,7 +132,7 @@ asc web apps availability create \
   --available-in-new-territories true
 ```
 
-After bootstrap, use the normal public API command for ongoing updates:
+After bootstrap, use the public API for ongoing changes:
 
 ```bash
 asc pricing availability edit \
@@ -137,22 +142,23 @@ asc pricing availability edit \
   --available-in-new-territories true
 ```
 
-### 2. Subscriptions are READY_TO_SUBMIT but not attached to first review
-For apps with subscriptions, check readiness explicitly:
+### Subscriptions are ready but not attached to first review
+
+Check subscription readiness first:
 
 ```bash
 asc validate subscriptions --app "APP_ID" --output table
 ```
 
-If the validator shows `MISSING_METADATA`, read the row-level diagnostics literally. The newest CLI surfaces missing promotional images, review screenshots, pricing or availability coverage, offer readiness, and app/build evidence in one matrix, which is the quickest way to understand why first-review attach still fails.
+If diagnostics report missing metadata, fix those prerequisites before attaching. Common misses are broad pricing coverage, review screenshots, promotional images, and app/build evidence.
 
-List current first-review subscription state:
+List first-review subscription state:
 
 ```bash
 asc web review subscriptions list --app "APP_ID"
 ```
 
-If the app is going through its first review and the group needs attaching:
+Attach a group for first review:
 
 ```bash
 asc web review subscriptions attach-group \
@@ -161,9 +167,7 @@ asc web review subscriptions attach-group \
   --confirm
 ```
 
-If `attach-group` still returns `MISSING_METADATA`, fix the validator-reported prerequisites first. The most common misses are broad pricing coverage and a subscription promotional image.
-
-For one subscription instead of a whole group:
+Attach one subscription instead:
 
 ```bash
 asc web review subscriptions attach \
@@ -172,64 +176,40 @@ asc web review subscriptions attach \
   --confirm
 ```
 
-For later reviews, use the normal submission path:
+For later reviews, submit subscriptions through the public review path:
 
 ```bash
 asc subscriptions review submit --subscription-id "SUB_ID" --confirm
 ```
 
-If review artifacts are missing, upload them before submission:
-
-```bash
-asc subscriptions review screenshots create --subscription-id "SUB_ID" --file "./screenshot.png"
-asc subscriptions images create --subscription-id "SUB_ID" --file "./image.png"
-```
-
-Also make sure the app’s privacy policy URL is populated when the app sells subscriptions.
-
-### 3. In-App Purchases need review readiness or first-version inclusion
-For apps with one-time purchases, consumables, or non-consumables, check readiness explicitly:
+### In-app purchases need review readiness or first-version inclusion
 
 ```bash
 asc validate iap --app "APP_ID" --output table
 ```
 
-If the IAP is missing its App Review screenshot:
+Upload missing review screenshots:
 
 ```bash
 asc iap review-screenshots create --iap-id "IAP_ID" --file "./review.png"
 ```
 
-For IAPs on a published app, submit them directly:
+For IAPs on a published app:
 
 ```bash
 asc iap submit --iap-id "IAP_ID" --confirm
 ```
 
-If this is the first IAP for the app, or the first time adding a new IAP type, Apple requires it to be included with a new app version. Current `asc` commands can validate and submit published-app IAPs, but there is no equivalent first-review attach flow like the subscription web commands yet. In that case:
-- prepare the IAP with `asc validate iap`, pricing, localization, and review screenshot data first
-- then select the IAP from the app version’s “In-App Purchases and Subscriptions” section in App Store Connect before submitting the app version
+For the first IAP on an app, or the first time adding a new IAP type, Apple may require selecting the IAP from the app version's "In-App Purchases and Subscriptions" section before submitting the app version. Prepare the IAP with localization, pricing, and review screenshot data first.
 
-Also make sure the app’s privacy policy URL is populated when the app sells IAPs.
-
-### 4. Game Center is enabled but the app version or review submission is incomplete
-If the app uses Game Center, make sure the App Store version is Game Center-enabled:
+### Game Center needs app-version and review-submission items
 
 ```bash
 asc game-center app-versions list --app "APP_ID"
 asc game-center app-versions create --app-store-version-id "VERSION_ID"
 ```
 
-If you are adding Game Center components for the first time, include them in the same submission as the app version. Resolve component version IDs first:
-
-```bash
-asc game-center achievements v2 versions list --achievement-id "ACH_ID"
-asc game-center leaderboards v2 versions list --leaderboard-id "LEADERBOARD_ID"
-asc game-center challenges versions list --challenge-id "CHALLENGE_ID"
-asc game-center activities versions list --activity-id "ACTIVITY_ID"
-```
-
-Then use the review-submission flow so you can add the app version and the Game Center component versions to the same submission:
+If Game Center component versions must ship with the app version, use the explicit review-submission API so all items can be added before submission:
 
 ```bash
 asc review submissions-create --app "APP_ID" --platform IOS
@@ -240,12 +220,9 @@ asc review submissions-submit --id "SUBMISSION_ID" --confirm
 
 `asc review items-add` also supports `gameCenterAchievementVersions`, `gameCenterActivityVersions`, `gameCenterChallengeVersions`, and `gameCenterLeaderboardSetVersions`.
 
-If Game Center component versions need to ship with the app version, prefer the explicit `asc review submissions-*` flow over `asc release run --confirm`, because you need a chance to add all submission items before final submit.
+### App Privacy is still unpublished
 
-### 5. App Privacy is still unpublished
-The public API can warn about App Privacy readiness but cannot fully verify publish state.
-
-If `asc submit preflight`, `asc validate`, or `asc release run` surfaces an App Privacy advisory, reconcile it with:
+The public API can surface privacy advisories, but it cannot fully verify App Privacy publish state.
 
 ```bash
 asc web privacy pull --app "APP_ID" --out "./privacy.json"
@@ -254,20 +231,19 @@ asc web privacy apply --app "APP_ID" --file "./privacy.json"
 asc web privacy publish --app "APP_ID" --confirm
 ```
 
-If the user does not want the experimental web-session flow, confirm App Privacy manually in App Store Connect:
+If the user avoids experimental web-session commands, confirm App Privacy manually in App Store Connect:
 
 ```text
 https://appstoreconnect.apple.com/apps/APP_ID/appPrivacy
 ```
 
-### 6. Review details are incomplete
-Check whether the version already has review details:
+### Review details are incomplete
 
 ```bash
 asc review details-for-version --version-id "VERSION_ID"
 ```
 
-If needed, create or update them:
+Create or update details:
 
 ```bash
 asc review details-create \
@@ -277,67 +253,32 @@ asc review details-create \
   --contact-email "dev@example.com" \
   --contact-phone "+1 555 0100" \
   --notes "Explain the reviewer access path here."
-```
 
-```bash
 asc review details-update \
   --id "DETAIL_ID" \
   --notes "Updated reviewer instructions."
 ```
 
-Only set `--demo-account-required=true` when App Review truly needs demo credentials.
+Only set demo-account fields when App Review truly needs demo credentials.
 
-## Practical readiness checklist
-An app is effectively ready to submit when:
-- `asc submit preflight --app "APP_ID" --version "VERSION"` reports no blocking issues
-- `asc validate --app "APP_ID" --version "VERSION"` is clean or only contains understood non-blocking warnings
-- `asc release stage --confirm` successfully prepared the target version when you want a real pre-submit checkpoint
-- `asc release run ... --dry-run` produces the expected plan
-- the build is `VALID` and attached to the target version
-- metadata, screenshots, and localizations are complete
-- content rights and encryption requirements are resolved
-- review details are present
-- app availability exists
-- if the app has IAPs or subscriptions, the privacy policy URL is present
-- if the app has IAPs, they have localization/pricing/review screenshots and first-time IAPs are selected with the app version
-- subscriptions, if any, are attached for first review or already submitted through the supported review path
-- if the app uses Game Center, the app version is Game Center-enabled and any required Game Center component versions are in the same review submission
-- any App Privacy advisory has been resolved through `asc web privacy ...` or manual confirmation
+## Ready checklist
 
-## Lower-level fallback
-Use the lower-level flow only when the user needs explicit control over each step:
+An app is effectively ready when:
 
-```bash
-asc versions attach-build --version-id "VERSION_ID" --build "BUILD_ID"
-asc submit preflight --app "APP_ID" --version "1.2.3" --platform IOS
-asc submit create --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --confirm
-asc submit status --version-id "VERSION_ID"
-# or, if you captured the review submission ID:
-asc submit status --id "SUBMISSION_ID"
-```
-
-If the submission needs multiple review items, such as Game Center component versions, use the review-submission API directly instead:
-
-```bash
-asc review submissions-create --app "APP_ID" --platform IOS
-asc review items-add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
-asc review items-add --submission "SUBMISSION_ID" --item-type gameCenterChallengeVersions --item-id "GC_CHALLENGE_VERSION_ID"
-asc review submissions-submit --id "SUBMISSION_ID" --confirm
-```
-
-## Platform notes
-- Use `--platform MAC_OS`, `TV_OS`, or `VISION_OS` as needed.
-- For macOS, upload the `.pkg` separately, then use the same readiness and submission flow.
-- `asc publish testflight` is still the fastest TestFlight shortcut, but for App Store readiness prefer `asc submit preflight`, `asc release stage`, and `asc release run`.
+- `asc validate --app "APP_ID" --version "VERSION" --platform IOS` has no blocking issues.
+- `asc release stage --dry-run` produces the expected plan, or `asc release stage --confirm` has successfully prepared the target version.
+- The build is `VALID` and attached to the target version.
+- Metadata, screenshots, app info, content rights, encryption, age rating, and review details are complete.
+- App availability exists.
+- Digital goods have localization, pricing, review screenshots, and any first-review attachments or manual selections handled.
+- Game Center app-version and component review items are included when needed.
+- App Privacy is confirmed or published.
 
 ## Notes
-- `asc release stage --confirm` is the safest one-command way to prepare a version without submitting it.
-- `asc release run --dry-run` is the closest thing to a one-command answer for "will this full release flow work?"
-- `asc submit preflight` is the fastest first pass.
-- `asc validate` is the deeper API-side checklist for version readiness.
-- `asc validate subscriptions` now exposes much richer per-subscription diagnostics for `MISSING_METADATA` readiness failures.
-- Web-session commands are experimental and should be presented as optional escape hatches when the public API cannot complete the first-time flow.
-- First-time app-availability bootstrap now goes through the experimental `asc web apps availability create` flow or App Store Connect itself.
-- First-review subscriptions have a concrete CLI attach path; first-review IAP selection still may require the App Store Connect version UI.
-- Game Center can require explicit review-submission item management when components must ride with the app version.
-- If the user asks "why did submission fail?" map the failure back into the three buckets above: API-fixable, web-session-fixable, or manual fallback.
+
+- Do not use the legacy submit-preflight, submit-create, or release-run shortcuts; they are not part of the current CLI.
+- Use `asc validate` for readiness.
+- Use `asc release stage` for pre-submit preparation.
+- Use `asc review submit` for explicit App Store review submission.
+- Use `asc publish appstore --submit --confirm` for high-level upload plus submission.
+- Use `asc status` and `asc submit status` after submission.

--- a/skills/asc-screenshot-resize/SKILL.md
+++ b/skills/asc-screenshot-resize/SKILL.md
@@ -1,70 +1,40 @@
 ---
 name: asc-screenshot-resize
-description: Resize and validate App Store screenshots for all device classes using macOS sips. Use when preparing or fixing screenshots for App Store Connect submission.
+description: Resize and validate App Store screenshots with current asc screenshot-size data and macOS sips. Use when preparing or fixing screenshots for App Store Connect submission.
 ---
 
 # asc screenshot resize
 
-Use this skill to resize screenshots to the exact pixel dimensions required by App Store Connect and validate they pass upload requirements. Uses the built-in macOS `sips` tool — no third-party dependencies needed.
+Use this skill to prepare screenshots for App Store Connect. Do not rely on a hard-coded dimension table in this skill; the CLI owns the current size matrix.
 
-## Required Dimensions
+## Source of truth
 
-### iPhone
+Always discover current accepted sizes from `asc` first:
 
-| Display Size | Accepted Dimensions (portrait × landscape) |
-|---|---|
-| 6.9" | 1260 × 2736, 2736 × 1260, 1320 × 2868, 2868 × 1320, 1290 × 2796, 2796 × 1290 |
-| 6.5" | 1242 × 2688, 2688 × 1242, 1284 × 2778, 2778 × 1284 |
-| 6.3" | 1206 × 2622, 2622 × 1206, 1179 × 2556, 2556 × 1179 |
-| 6.1" | 1125 × 2436, 2436 × 1125, 1080 × 2340, 2340 × 1080, 1170 × 2532, 2532 × 1170 |
-| 5.5" | 1242 × 2208, 2208 × 1242 |
-| 4.7" | 750 × 1334, 1334 × 750 |
-| 4" | 640 × 1096, 640 × 1136, 1136 × 600, 1136 × 640 |
-| 3.5" | 640 × 920, 640 × 960, 960 × 600, 960 × 640 |
+```bash
+asc screenshots sizes --output table
+asc screenshots sizes --all --output table
+```
 
-**Note:** 6.9" accepts screenshots from 6.5", 6.7", and 6.9" devices. 6.3" accepts from 6.1" and 6.3". 6.1" accepts from 5.4", 5.8", and 6.1".
+For local validation before upload:
 
-### iPad
+```bash
+asc screenshots validate --path "./screenshots/iphone" --device-type "IPHONE_65" --output table
+asc screenshots validate --path "./screenshots/ipad" --device-type "IPAD_PRO_3GEN_129" --output table
+```
 
-| Display Size | Accepted Dimensions |
-|---|---|
-| 13" | 2064 × 2752, 2752 × 2064, 2048 × 2732, 2732 × 2048 |
-| 11" | 1668 × 2420, 2420 × 1668, 1668 × 2388, 2388 × 1668, 1640 × 2360, 2360 × 1640, 1488 × 2266, 2266 × 1488 |
-| iPad Pro 2nd gen 12.9" | 2048 × 2732, 2732 × 2048 |
-| 10.5" | 1668 × 2224, 2224 × 1668 |
-| 9.7" | 1536 × 2008, 1536 × 2048, 2048 × 1496, 2048 × 1536, 768 × 1004, 768 × 1024, 1024 × 748, 1024 × 768 |
+Common current device-type anchors:
 
-### Apple Watch
+- `IPHONE_65` for the common 6.5-inch iPhone screenshot set.
+- `IPAD_PRO_3GEN_129` for the common 12.9/13-inch iPad screenshot set.
 
-| Device | Dimensions |
-|---|---|
-| Ultra 3 (49mm) | 422 × 514, 410 × 502 |
-| Series 11 (46mm) | 416 × 496 |
-| Series 9 (45mm) | 396 × 484 |
-| Series 6 (44mm) | 368 × 448 |
-| Series 3 (42mm) | 312 × 390 |
-
-### Mac
-
-| Dimensions |
-|---|
-| 1280 × 800 |
-| 1440 × 900 |
-| 2560 × 1600 |
-| 2880 × 1800 |
-
-### Apple TV
-
-| Dimensions |
-|---|
-| 1920 × 1080 |
-| 3840 × 2160 |
+Run `asc screenshots sizes --all` when targeting other display types such as 6.9-inch iPhone, Apple TV, Mac, Vision Pro, iMessage, or Watch.
 
 ## Workflow
 
-### 1. Fix Unicode filenames
+### 1. Sanitize filenames
 
-macOS screenshots often contain hidden Unicode characters (e.g., `U+202F` narrow no-break space) that cause `sips` and other tools to fail with "not a valid file". Always sanitize first:
+macOS screenshots can contain hidden Unicode spaces that make tools fail with "not a valid file". Sanitize before batch work:
 
 ```bash
 python3 -c "
@@ -77,51 +47,44 @@ for f in os.listdir('.'):
 "
 ```
 
-### 2. Check current dimensions
+### 2. Inspect dimensions and metadata
 
 ```bash
 sips -g pixelWidth -g pixelHeight screenshot.png
-```
-
-### 3. Validate App Store readiness
-
-Check for alpha channel and color space issues before uploading:
-
-```bash
 sips -g hasAlpha -g space screenshot.png
 ```
 
-App Store Connect rejects screenshots with alpha transparency. Remove it by round-tripping through JPEG:
+App Store Connect rejects screenshots with alpha transparency. Strip alpha by round-tripping through JPEG:
 
 ```bash
-sips -s format jpeg input.png --out /tmp/temp.jpg
-sips -s format png /tmp/temp.jpg --out output.png
-rm /tmp/temp.jpg
+sips -s format jpeg input.png --out /tmp/asc-screenshot-no-alpha.jpg
+sips -s format png /tmp/asc-screenshot-no-alpha.jpg --out output.png
+rm /tmp/asc-screenshot-no-alpha.jpg
 ```
 
-Batch-strip alpha from all PNGs in a directory:
+Batch-strip alpha from PNGs:
 
 ```bash
 for f in *.png; do
   if sips -g hasAlpha "$f" | grep -q "yes"; then
-    sips -s format jpeg "$f" --out /tmp/temp.jpg
-    sips -s format png /tmp/temp.jpg --out "$f"
-    rm /tmp/temp.jpg
+    sips -s format jpeg "$f" --out /tmp/asc-screenshot-no-alpha.jpg
+    sips -s format png /tmp/asc-screenshot-no-alpha.jpg --out "$f"
+    rm /tmp/asc-screenshot-no-alpha.jpg
     echo "Stripped alpha: $f"
   fi
 done
 ```
 
-### 4. Resize a single screenshot
+### 3. Resize only after choosing a target from asc
+
+Pick a width and height from `asc screenshots sizes --all`. `sips -z` takes height first, then width:
 
 ```bash
-# Portrait iPhone 6.5" (1284 × 2778)
+# Example: portrait IPHONE_65 1284 x 2778
 sips -z 2778 1284 input.png --out output.png
 ```
 
-**Note:** `sips -z` takes height first, then width: `sips -z <height> <width>`.
-
-### 5. Batch resize all screenshots in a directory
+Batch resize to a chosen target:
 
 ```bash
 mkdir -p resized
@@ -130,30 +93,30 @@ for f in *.png; do
 done
 ```
 
-### 6. Generate multiple device sizes from one source
-
-```bash
-mkdir -p appstore-screenshots
-# iPhone
-sips -z 2868 1320 input.png --out appstore-screenshots/iphone-6.9.png
-sips -z 2778 1284 input.png --out appstore-screenshots/iphone-6.5.png
-sips -z 2622 1206 input.png --out appstore-screenshots/iphone-6.3.png
-sips -z 2532 1170 input.png --out appstore-screenshots/iphone-6.1.png
-sips -z 2208 1242 input.png --out appstore-screenshots/iphone-5.5.png
-```
-
-### 7. Verify output
+### 4. Validate outputs with asc
 
 ```bash
 sips -g pixelWidth -g pixelHeight -g hasAlpha resized/*.png
+asc screenshots validate --path "./resized" --device-type "IPHONE_65" --output table
 ```
 
-Confirm all files show the target dimensions and `hasAlpha: no`.
+### 5. Upload only after validation
+
+```bash
+asc screenshots upload --version-localization "LOC_ID" --path "./resized" --device-type "IPHONE_65" --dry-run --output table
+asc screenshots upload --version-localization "LOC_ID" --path "./resized" --device-type "IPHONE_65"
+```
 
 ## Guardrails
 
-- `sips` stretches images to fit exact dimensions. For best results, use source screenshots captured at or near the target aspect ratio.
-- Always output to a separate file or directory (`--out`) to preserve originals.
-- App Store Connect requires PNG or JPEG format. `sips` preserves the input format by default.
-- Screenshots **must not** include alpha transparency. Always validate with `sips -g hasAlpha` before upload.
-- Color space must be sRGB. If screenshots use Display P3, convert with: `sips -m "/System/Library/ColorSync/Profiles/sRGB IEC61966-2.1.icc" input.png --out output.png`.
+- Treat `asc screenshots sizes --all` as authoritative; Apple size requirements change.
+- Do not stretch screenshots across incompatible aspect ratios unless the user accepts the visual tradeoff.
+- Always output to a separate file or directory to preserve originals.
+- Screenshots must be PNG or JPEG and must not include alpha transparency.
+- Convert Display P3 or other color spaces to sRGB when needed:
+
+```bash
+sips -m "/System/Library/ColorSync/Profiles/sRGB IEC61966-2.1.icc" input.png --out output.png
+```
+
+- Prefer `asc screenshots validate` over visual inspection before upload.

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -1,37 +1,56 @@
 ---
 name: asc-submission-health
-description: Preflight App Store submissions, submit builds, and monitor review status with asc. Use when shipping or troubleshooting review submissions.
+description: Validate App Store submission readiness, submit prepared versions, and monitor review status with current asc commands. Use when shipping or troubleshooting review submissions.
 ---
 
 # asc submission health
 
-Use this skill to reduce review submission failures and monitor status.
+Use this skill to reduce review submission failures and monitor review state. The current readiness command is `asc validate`; legacy submit-preflight and submit-create shortcuts must not be used.
 
 ## Preconditions
+
 - Auth configured and app/version/build IDs resolved.
-- Build is processed (not in processing state).
-- All required metadata is complete.
+- Build processing completed or the command uses a high-level flow with `--wait`.
+- Metadata, app info, screenshots, review details, content rights, encryption, pricing, and availability are expected to be complete.
 
-## Pre-submission Checklist
+## Pre-submission checklist
 
-### 1. Verify Build Status
+### 1. Verify build status
+
 ```bash
 asc builds info --build-id "BUILD_ID"
 ```
+
 Check:
-- `processingState` is `VALID`
-- `usesNonExemptEncryption` - if `true`, requires encryption declaration
 
-### 2. Encryption Compliance
-If `usesNonExemptEncryption: true`:
+- `processingState` is `VALID`.
+- encryption fields are understood before submission.
+
+### 2. Run canonical readiness validation
+
 ```bash
-# If the app should be exempt, patch the local plist helper, rebuild, and re-upload
-asc encryption declarations exempt-declare --plist "./Info.plist"
+asc validate --app "APP_ID" --version "1.2.3" --platform IOS --output table
+```
 
-# List existing declarations
+Use strict mode when warnings should fail automation:
+
+```bash
+asc validate --app "APP_ID" --version "1.2.3" --platform IOS --strict --output table
+```
+
+If you already have the exact version ID:
+
+```bash
+asc validate --app "APP_ID" --version-id "VERSION_ID" --platform IOS --output table
+```
+
+### 3. Encryption compliance
+
+If the build uses non-exempt encryption:
+
+```bash
 asc encryption declarations list --app "APP_ID"
 
-# Create declaration if needed
 asc encryption declarations create \
   --app "APP_ID" \
   --app-description "Uses standard HTTPS/TLS" \
@@ -39,69 +58,77 @@ asc encryption declarations create \
   --contains-third-party-cryptography=true \
   --available-on-french-store=true
 
-# Assign to build
 asc encryption declarations assign-builds \
   --id "DECLARATION_ID" \
   --build "BUILD_ID"
 ```
 
-If the app truly uses only exempt transport encryption, prefer `asc encryption declarations exempt-declare --plist "./Info.plist"` and rebuild instead of creating a declaration that does not match the binary.
+If the app truly uses only exempt transport encryption, prefer updating the local plist and rebuilding:
 
-### 3. Content Rights Declaration
-Required for all App Store submissions:
 ```bash
-# Check current status
-asc apps content-rights view --app "APP_ID"
+asc encryption declarations exempt-declare --plist "./Info.plist"
+```
 
-# Set it for most apps
+### 4. Content rights declaration
+
+```bash
+asc apps content-rights view --app "APP_ID"
 asc apps content-rights edit --app "APP_ID" --uses-third-party-content=false
 ```
-Valid values:
-- `DOES_NOT_USE_THIRD_PARTY_CONTENT`
-- `USES_THIRD_PARTY_CONTENT`
 
-### 4. Version Metadata
-```bash
-# Check version details
-asc versions view --version-id "VERSION_ID" --include-build
-
-# Verify copyright is set
-asc versions update --version-id "VERSION_ID" --copyright "2026 Your Company"
-```
-
-### 5. Localizations Complete
-```bash
-# List version localizations
-asc localizations list --version "VERSION_ID"
-
-# Check required fields: description, keywords, whatsNew, supportUrl
-```
-
-### 6. Screenshots Present
-Each locale needs screenshots for the target platform.
-
-### 7. App Info Localizations (Privacy Policy)
-```bash
-# List app info IDs (if multiple exist)
-asc apps info list --app "APP_ID"
-
-# Check privacy policy URL
-asc localizations list --app "APP_ID" --type app-info --app-info "APP_INFO_ID"
-```
-
-### 8. App Privacy readiness advisory
-`asc` can warn about App Privacy readiness, but the public App Store Connect API
-cannot verify whether App Privacy is fully published. Before final submission:
+### 5. Version metadata and localizations
 
 ```bash
-asc submit preflight --app "APP_ID" --version "1.2.3" --platform IOS
-asc validate --app "APP_ID" --version "1.2.3" --platform IOS
+asc versions view --version-id "VERSION_ID" --include-build --include-submission
+asc localizations list --version "VERSION_ID" --output table
 ```
 
-Prefer the version string form for top-level readiness checks in this skill so it stays aligned with `asc submit preflight`. Lower-level commands later in this guide still use `VERSION_ID` where the API requires it.
+For canonical metadata repair:
 
-If either command reports an App Privacy advisory, the public API cannot verify
-publish state. Use the web-session privacy workflow if you rely on those endpoints:
+```bash
+asc metadata pull --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
+asc metadata validate --dir "./metadata" --output table
+asc metadata push --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata" --dry-run --output table
+asc metadata push --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
+```
+
+### 6. App info localizations and privacy policy
+
+```bash
+asc apps info list --app "APP_ID" --output table
+asc localizations list --app "APP_ID" --type app-info --app-info "APP_INFO_ID" --output table
+```
+
+For subscription or IAP apps, make sure privacy policy URL is populated:
+
+```bash
+asc app-setup info set --app "APP_ID" --primary-locale "en-US" --privacy-policy-url "https://example.com/privacy"
+```
+
+### 7. Screenshots
+
+```bash
+asc screenshots list --version-localization "LOC_ID" --output table
+asc screenshots sizes --output table
+asc screenshots validate --path "./screenshots" --device-type "IPHONE_65" --output table
+```
+
+### 8. Digital goods readiness
+
+```bash
+asc validate iap --app "APP_ID" --output table
+asc validate subscriptions --app "APP_ID" --output table
+```
+
+Use JSON when you need exact diagnostics:
+
+```bash
+asc validate subscriptions --app "APP_ID" --output json --pretty
+```
+
+### 9. App Privacy advisory
+
+The public API cannot fully verify App Privacy publish state. If validation reports an advisory, use the experimental web-session flow or confirm manually.
 
 ```bash
 asc web privacy pull --app "APP_ID" --out "./privacy.json"
@@ -110,98 +137,96 @@ asc web privacy apply --app "APP_ID" --file "./privacy.json"
 asc web privacy publish --app "APP_ID" --confirm
 ```
 
-If you do not want to use the experimental `asc web privacy ...` commands,
-confirm App Privacy manually in App Store Connect:
+Manual fallback:
 
 ```text
 https://appstoreconnect.apple.com/apps/APP_ID/appPrivacy
 ```
 
-### 9. Digital goods readiness (IAPs / subscriptions)
-If the app sells subscriptions or in-app purchases, validate those separately before submit:
-
-```bash
-asc validate iap --app "APP_ID" --output table
-asc validate subscriptions --app "APP_ID" --output table
-```
-
-In current asc, `asc validate subscriptions` expands `MISSING_METADATA` into a per-subscription diagnostics matrix. Use it to identify missing review screenshots, promotional images, pricing or availability coverage gaps, offer readiness, and app/build evidence before retrying submit or first-review attach.
-
-Use `--output json --pretty` when you want exact territory gaps in machine-readable form.
-
 ## Submit
 
-### Using Review Submissions API (Recommended)
+### Submit a prepared version
+
+Use `asc review submit` for explicit App Store review submission:
+
 ```bash
-# Create submission
+asc review submit --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --dry-run --output table
+asc review submit --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --confirm
+```
+
+Use `--version-id "VERSION_ID"` when you have already resolved the version.
+
+### Upload and submit in one flow
+
+```bash
+asc publish appstore --app "APP_ID" --ipa "./App.ipa" --version "1.2.3" --submit --dry-run --output table
+asc publish appstore --app "APP_ID" --ipa "./App.ipa" --version "1.2.3" --submit --confirm
+```
+
+Add `--wait` when the command should wait for build processing.
+
+### Multi-item review submissions
+
+Use the lower-level review-submission API when the submission needs multiple review items, such as Game Center component versions:
+
+```bash
 asc review submissions-create --app "APP_ID" --platform IOS
-
-# Add version to submission
-asc review items-add \
-  --submission "SUBMISSION_ID" \
-  --item-type appStoreVersions \
-  --item-id "VERSION_ID"
-
-# Submit for review
+asc review items-add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
+asc review items-add --submission "SUBMISSION_ID" --item-type gameCenterChallengeVersions --item-id "GC_CHALLENGE_VERSION_ID"
 asc review submissions-submit --id "SUBMISSION_ID" --confirm
 ```
 
-### Using Submit Command
-```bash
-asc submit preflight --app "APP_ID" --version "1.2.3" --platform IOS
-asc submit create --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --confirm
-```
-Use `--platform` when multiple platforms exist.
-
 ## Monitor
+
 ```bash
-# Check submission status
+asc status --app "APP_ID"
 asc submit status --id "SUBMISSION_ID"
 asc submit status --version-id "VERSION_ID"
-
-# List all submissions
 asc review submissions-list --app "APP_ID" --paginate
 ```
 
-## Cancel / Retry
-```bash
-# Cancel submission
-asc submit cancel --id "SUBMISSION_ID" --confirm
+## Cancel and retry
 
-# Or via review API
+```bash
+asc submit cancel --id "SUBMISSION_ID" --confirm
+asc submit cancel --version-id "VERSION_ID" --app "APP_ID" --confirm
 asc review submissions-cancel --id "SUBMISSION_ID" --confirm
 ```
-Fix issues, then re-submit.
 
-## Common Submission Errors
+Fix validation issues, then submit again with `asc review submit` or `asc publish appstore --submit --confirm`.
 
-### "Version is not in valid state"
+## Common submission errors
+
+### Version is not in valid state
+
 Check:
-1. Build is attached and VALID
-2. Encryption declaration approved (or exempt)
-3. Content rights declaration set
-4. All localizations complete
-5. Screenshots present for all locales
-6. App Privacy has been reviewed and published in App Store Connect
 
-### "Export compliance must be approved"
-The build has `usesNonExemptEncryption: true`. Either:
-- Upload export compliance documentation
-- Or rebuild with `ITSAppUsesNonExemptEncryption = NO` in Info.plist
+1. Build is attached and `VALID`.
+2. Encryption declaration is resolved or exempt.
+3. Content rights declaration is set.
+4. Required localizations and screenshots are present.
+5. Review details are present.
+6. Pricing and availability exist.
+7. App Privacy has been reviewed and published in App Store Connect.
 
-### "Multiple app infos found"
-Use `--app-info` flag with the correct app info ID:
+### Export compliance must be approved
+
+Either upload export compliance documentation or rebuild with exempt encryption metadata if that accurately describes the app.
+
+### Multiple app infos found
+
+Use the exact app-info ID:
+
 ```bash
-asc apps info list --app "APP_ID"
+asc apps info list --app "APP_ID" --output table
 ```
 
 ## Notes
-- `asc submit create` uses the new reviewSubmissions API automatically.
-- `asc submit preflight` can return non-blocking advisories; review them before submitting.
-- App Privacy publish state is not verifiable via the public API.
-- Prefer `asc apps content-rights view/edit` over ad-hoc app JSON inspection.
-- `asc validate subscriptions` now provides much richer per-subscription diagnostics for `MISSING_METADATA` cases.
-- If you use ASC web-session flows, `asc web privacy pull|plan|apply|publish` is the CLI path for App Privacy.
-- If you avoid the experimental web-session commands, confirm App Privacy manually in App Store Connect.
-- Use `--output table` when you want human-readable status.
-- macOS submissions follow the same process but use `--platform MAC_OS`.
+
+- Do not use legacy submit-preflight or submit-create shortcuts; they are removed.
+- Use `asc validate` for readiness.
+- Use `asc review submit` for prepared-version submission.
+- Use `asc publish appstore --submit --confirm` for high-level upload plus submission.
+- App Privacy publish state is not fully verifiable through the public API.
+- Use `--output table` for human status and JSON for automation.
+- macOS submissions follow the same review flow but use `--platform MAC_OS`.

--- a/skills/asc-workflow/SKILL.md
+++ b/skills/asc-workflow/SKILL.md
@@ -1,217 +1,185 @@
 ---
 name: asc-workflow
-description: Define, validate, and run repo-local multi-step automations with `asc workflow` and `.asc/workflow.json`. Use when migrating from lane tools, wiring CI pipelines, or orchestrating repeatable `asc` + shell release flows with hooks, conditionals, and sub-workflows.
+description: Define, validate, run, resume, and audit repo-local multi-step automations with current `asc workflow` and `.asc/workflow.json`, including step outputs and safe release/TestFlight workflows.
 ---
 
 # asc workflow
 
 Use this skill when you need lane-style automation inside the CLI using:
-- `asc workflow run`
+
 - `asc workflow validate`
 - `asc workflow list`
+- `asc workflow run`
 
-This feature is best for deterministic automation that lives in your repo, is reviewable in PRs, and can run the same way locally and in CI.
+Workflows are repo-local automation files. They run trusted shell commands, stream step output to stderr, and keep stdout as machine-readable JSON.
 
 ## Command discovery
 
-- Always use `--help` to confirm flags and subcommands:
-  - `asc workflow --help`
-  - `asc workflow run --help`
-  - `asc workflow validate --help`
-  - `asc workflow list --help`
+Always verify flags with:
+
+```bash
+asc workflow --help
+asc workflow validate --help
+asc workflow list --help
+asc workflow run --help
+```
 
 ## End-to-end flow
 
-1. Author `.asc/workflow.json`
+1. Author `.asc/workflow.json`.
 2. Validate structure and references:
-   - `asc workflow validate`
-3. Discover available workflows:
-   - `asc workflow list`
-   - `asc workflow list --all` (includes private helpers)
-4. Preview execution without side effects:
-   - `asc workflow run --dry-run beta`
-5. Execute with runtime params:
-   - `asc workflow run beta BUILD_ID:123456789 GROUP_ID:abcdef`
+
+```bash
+asc workflow validate
+```
+
+3. Discover public workflows:
+
+```bash
+asc workflow list
+asc workflow list --all
+```
+
+4. Preview execution:
+
+```bash
+asc workflow run --dry-run beta BUILD_ID:123456789 GROUP_ID:abcdef
+```
+
+5. Execute:
+
+```bash
+asc workflow run beta BUILD_ID:123456789 GROUP_ID:abcdef
+```
+
+6. If a recoverable run fails, resume with the run ID from the JSON result:
+
+```bash
+asc workflow run release --resume "release-20260312T120000Z-deadbeef"
+```
+
+Do not pass extra `KEY:VALUE` params with `--resume`; the saved workflow file, params, and persisted outputs are reused.
 
 ## File location and format
 
 - Default path: `.asc/workflow.json`
 - Override path: `asc workflow run --file ./path/to/workflow.json <name>`
-- JSONC comments are supported (`//` and `/* ... */`)
+- JSONC comments are supported.
+- Top-level hooks: `before_all`, `after_all`, `error`
+- Workflow keys: `description`, `private`, `env`, `steps`
+- Step forms:
+  - string shorthand: `"echo hello"`
+  - `run` shell command
+  - `workflow` sub-workflow call
+  - `name` label
+  - `if` conditional var name
+  - `with` env overrides for workflow-call steps
+  - `outputs` map for JSON stdout extraction from named run steps
 
-## Output and CI contract
+## Outputs
 
-- `stdout`: structured JSON result (`status`, `steps`, durations)
-- `stderr`: step command output, hook output, dry-run previews
-- `asc workflow validate` always prints JSON and returns non-zero when invalid
+Run steps can declare outputs. The command must emit JSON on stdout, so pass `--output json` for `asc` commands that produce outputs.
 
-This enables machine-safe checks:
+Output references use:
 
-```bash
-asc workflow validate | jq -e '.valid == true'
-asc workflow run beta BUILD_ID:123 GROUP_ID:xyz | jq -e '.status == "ok"'
+```text
+${steps.step_name.OUTPUT_NAME}
 ```
 
-## Schema (what the feature supports)
+Rules:
 
-Top-level keys:
-- `env`: global defaults
-- `before_all`: command run once before steps
-- `after_all`: command run once after successful steps
-- `error`: command run when any failure occurs
-- `workflows`: named workflow map
+- A step that declares `outputs` must have a reference-safe `name`.
+- Outputs are allowed on `run` steps, not workflow-call steps.
+- Output-producing names must be unique across workflows that can execute together in the same run graph.
+- Persisted outputs are stored in workflow run state, so do not map secrets into outputs.
 
-Workflow keys:
-- `description`
-- `private` (not directly runnable)
-- `env`
-- `steps`
+## Runtime params
 
-Step forms:
-- String shorthand: `"echo hello"` -> run step
-- Object with:
-  - `run`: shell command
-  - `workflow`: call sub-workflow
-  - `name`: label for reporting
-  - `if`: conditional var name
-  - `with`: env overrides for workflow-call steps only
+`asc workflow run <name> [KEY:VALUE ...]` supports both separators:
 
-## Runtime params (`KEY:VALUE` / `KEY=VALUE`)
+```bash
+asc workflow run beta VERSION:2.1.0
+asc workflow run beta VERSION=2.1.0
+```
 
-- `asc workflow run <name> [KEY:VALUE ...]` supports both separators:
-  - `VERSION:2.1.0`
-  - `VERSION=2.1.0`
-- If both separators exist, the first one wins.
-- Repeated keys are last-write-wins.
-- In step commands, reference params via shell expansion (`$VAR`).
-- Avoid putting secrets in `.asc/workflow.json`; pass them via CI secrets/env.
-
-## Run-tail flags
-
-`asc workflow run` also accepts core flags after the workflow name:
-- `--dry-run`
-- `--pretty`
-- `--file`
-
-Examples:
-- `asc workflow run beta --dry-run`
-- `asc workflow run beta --file .asc/workflow.json BUILD_ID:123`
-
-## Execution semantics
-
-- `before_all` runs once before step execution
-- `after_all` runs only when steps succeed
-- `error` runs on failure (step failure, before/after hook failure)
-- Sub-workflows are executed inline as part of the call step
-- Maximum sub-workflow nesting depth is 16
+Repeated keys are last-write-wins. In shell commands, reference params through shell expansion like `$VERSION`.
 
 ## Env precedence
 
 Main workflow run:
-- `definition.env` < `workflow.env` < CLI params
 
-Sub-workflow call step (`"workflow": "...", "with": {...}`):
-- sub-workflow `env` defaults
-- caller env (including CLI params) overrides
-- step `with` overrides all
+```text
+definition.env < workflow.env < CLI params
+```
 
-## Sub-workflows and private workflows
+Sub-workflow call with `with`:
 
-- Use `"workflow": "<name>"` to call helper workflows.
-- Use `"private": true` for helper-only workflows.
-- Private workflows:
-  - cannot be run directly
-  - can be called by other workflows
-  - are hidden from `asc workflow list` unless `--all` is used
-- Validation catches unknown workflow references and cyclic references.
+```text
+sub-workflow env < caller env and params < step with
+```
 
-## Conditionals (`if`)
+## Conditionals
 
-- Add `"if": "VAR_NAME"` on a step.
-- Step runs only if `VAR_NAME` is truthy.
-- Truthy: `1`, `true`, `yes`, `y`, `on` (case-insensitive).
-- Resolution order for `if` lookup:
-  1. merged workflow env/params
-  2. `os.Getenv(VAR_NAME)`
+Add `"if": "VAR_NAME"` to a step. Truthy values are `1`, `true`, `yes`, `y`, and `on`, case-insensitive. Lookup checks merged workflow env/params first, then process environment.
 
-## Dry-run behavior
-
-- `asc workflow run --dry-run <name>` does not execute commands.
-- It prints previews to `stderr`.
-- Dry-run shows raw commands (without env expansion), which helps avoid secret leakage in previews.
-
-## Shell behavior
-
-- Run steps use `bash -o pipefail -c` when bash is available.
-- Fallback is `sh -c` when bash is unavailable.
-- Pipelines therefore fail correctly in most CI shells when bash exists.
-
-## Practical authoring rules
-
-- Keep workflow files in version control.
-- Use IDs in step commands where possible for deterministic automation.
-- Use `--confirm` for destructive `asc` operations inside steps.
-- Validate first, then dry-run, then real run.
-- Keep hooks lightweight and side-effect aware.
+## Example workflow
 
 ```json
 {
   "env": {
     "APP_ID": "123456789",
-    "VERSION": "1.0.0"
+    "VERSION": "1.0.0",
+    "GROUP_ID": ""
   },
   "before_all": "asc auth status",
   "after_all": "echo workflow_done",
   "error": "echo workflow_failed",
   "workflows": {
     "beta": {
-      "description": "Distribute a build to a TestFlight group and notify",
-      "env": {
-        "GROUP_ID": ""
-      },
+      "description": "Resolve the latest build and distribute it to TestFlight",
       "steps": [
         {
-          "name": "list_builds",
-          "run": "asc builds list --app $APP_ID --sort -uploadedDate --limit 5"
+          "name": "resolve_build",
+          "run": "asc builds info --app $APP_ID --latest --platform IOS --output json",
+          "outputs": {
+            "BUILD_ID": "$.data.id"
+          }
         },
         {
           "name": "list_groups",
-          "run": "asc testflight groups list --app $APP_ID --limit 20"
+          "run": "asc testflight groups list --app $APP_ID --limit 20 --output json"
         },
         {
           "name": "add_build_to_group",
-          "if": "BUILD_ID",
-          "run": "asc builds add-groups --build-id $BUILD_ID --group $GROUP_ID"
-        },
-        {
-          "name": "notify",
-          "if": "SLACK_WEBHOOK",
-          "run": "echo sent_release_notice"
+          "if": "GROUP_ID",
+          "run": "asc builds add-groups --build-id ${steps.resolve_build.BUILD_ID} --group $GROUP_ID"
         }
       ]
     },
     "release": {
-      "description": "Submit a version for App Store review",
+      "description": "Validate, stage, and submit an App Store version",
       "steps": [
         {
-          "workflow": "sync-metadata",
-          "with": {
-            "METADATA_DIR": "./metadata"
-          }
+          "name": "validate",
+          "run": "asc validate --app $APP_ID --version $VERSION --platform IOS --output json"
+        },
+        {
+          "name": "stage",
+          "run": "asc release stage --app $APP_ID --version $VERSION --build $BUILD_ID --metadata-dir ./metadata/version/$VERSION --confirm --output json"
         },
         {
           "name": "submit",
-          "run": "asc submit create --app $APP_ID --version $VERSION --build $BUILD_ID --confirm"
+          "if": "SUBMIT_FOR_REVIEW",
+          "run": "asc review submit --app $APP_ID --version $VERSION --build $BUILD_ID --confirm --output json"
         }
       ]
     },
-    "sync-metadata": {
-      "private": true,
-      "description": "Private helper workflow (callable only via workflow steps)",
+    "publish-appstore": {
+      "description": "High-level upload plus App Store review submission",
       "steps": [
         {
-          "name": "migrate_validate",
-          "run": "echo METADATA_DIR_is_$METADATA_DIR"
+          "name": "publish",
+          "run": "asc publish appstore --app $APP_ID --ipa ./build/MyApp.ipa --version $VERSION --wait --submit --confirm --output json"
         }
       ]
     }
@@ -222,18 +190,20 @@ Sub-workflow call step (`"workflow": "...", "with": {...}`):
 ## Useful invocations
 
 ```bash
-# Validate and fail CI on invalid file
 asc workflow validate | jq -e '.valid == true'
-
-# Show discoverable workflows
 asc workflow list --pretty
-
-# Include private helpers
 asc workflow list --all --pretty
-
-# Preview a real run
 asc workflow run --dry-run beta BUILD_ID:123 GROUP_ID:grp_abc
-
-# Run with params and assert success
 asc workflow run beta BUILD_ID:123 GROUP_ID:grp_abc | jq -e '.status == "ok"'
+asc workflow run release BUILD_ID:123 SUBMIT_FOR_REVIEW:true
+asc workflow run release --resume "release-20260312T120000Z-deadbeef"
 ```
+
+## Safety rules
+
+- Treat `.asc/workflow.json` like code; only run trusted workflow files.
+- Avoid running workflows from untrusted PRs with secrets.
+- Keep workflow files in version control.
+- Validate first, dry-run next, then run.
+- Use explicit IDs and `--confirm` for mutating steps.
+- Use `asc validate`, `asc release stage`, `asc review submit`, and `asc publish appstore`; do not use removed submission commands.

--- a/skills/asc-xcode-build/SKILL.md
+++ b/skills/asc-xcode-build/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: asc-xcode-build
-description: Build, archive, export, and manage Xcode version/build numbers with asc and xcodebuild before uploading to App Store Connect. Use when you need to create an IPA or PKG for upload.
+description: Build, archive, export, upload, and manage Xcode version/build numbers with the current asc xcode helpers before App Store Connect upload or submission. Use when creating an IPA or PKG for upload.
 ---
 
-# Xcode Build and Export
+# Xcode build and export
 
-Use this skill when you need to build an app from source and prepare it for upload to App Store Connect.
+Use this skill when you need to build an app from source and prepare it for App Store Connect. Prefer `asc xcode archive` and `asc xcode export` over raw `xcodebuild` recipes when they fit the project.
 
 ## Preconditions
-- Xcode installed and command line tools configured
-- Valid signing identity and provisioning profiles (or automatic signing enabled)
 
-## Manage version and build numbers with `asc`
-Before archiving, prefer `asc xcode version ...` over manual `pbxproj` edits when you need to inspect or bump app versions.
+- Xcode and command line tools are installed.
+- Signing identity and provisioning profiles are available, or automatic signing is enabled.
+- App Store Connect auth is configured when upload or build lookup is needed.
+
+## Manage version and build numbers
 
 ```bash
 asc xcode version view
@@ -21,112 +22,143 @@ asc xcode version bump --type build
 asc xcode version bump --type patch
 ```
 
-Notes:
-- Use `--project-dir "./MyApp"` when you are not running from the project root.
-- Use `--target "App"` for deterministic reads in multi-target projects.
-- These commands support both legacy `agvtool` projects and modern `MARKETING_VERSION` / `CURRENT_PROJECT_VERSION` setups.
+Use `--project-dir "./MyApp"` when not running from the project root. Use `--project "./MyApp/App.xcodeproj"` when the directory contains multiple projects. Use `--target "App"` for deterministic reads in multi-target projects.
 
-## iOS Build Flow
+To avoid low build-number rejects, resolve a remote-safe build number first:
 
-### 1. Clean and Archive
 ```bash
-xcodebuild clean archive \
-  -scheme "YourScheme" \
-  -configuration Release \
-  -archivePath /tmp/YourApp.xcarchive \
-  -destination "generic/platform=iOS"
+asc builds next-build-number --app "APP_ID" --version "1.2.3" --platform IOS --output json
+asc xcode version edit --build-number "NEXT_BUILD"
 ```
 
-### 2. Export IPA
+## Preferred iOS/tvOS/visionOS build flow
+
+### 1. Archive with asc
+
+```bash
+asc xcode archive \
+  --workspace "App.xcworkspace" \
+  --scheme "App" \
+  --configuration Release \
+  --clean \
+  --archive-path ".asc/artifacts/App.xcarchive" \
+  --xcodebuild-flag=-destination \
+  --xcodebuild-flag=generic/platform=iOS \
+  --output json
+```
+
+Use `--project "App.xcodeproj"` instead of `--workspace` for project-only apps.
+
+### 2. Export with asc
+
+```bash
+asc xcode export \
+  --archive-path ".asc/artifacts/App.xcarchive" \
+  --export-options "ExportOptions.plist" \
+  --ipa-path ".asc/artifacts/App.ipa" \
+  --xcodebuild-flag=-allowProvisioningUpdates \
+  --output json
+```
+
+If `ExportOptions.plist` uses direct App Store Connect upload, add `--wait` to poll for build discovery and processing:
+
+```bash
+asc xcode export \
+  --archive-path ".asc/artifacts/App.xcarchive" \
+  --export-options "UploadExportOptions.plist" \
+  --ipa-path ".asc/artifacts/App.ipa" \
+  --wait \
+  --output json
+```
+
+### 3. Upload or publish
+
+Upload an exported IPA:
+
+```bash
+asc builds upload --app "APP_ID" --ipa ".asc/artifacts/App.ipa" --wait
+```
+
+Distribute to TestFlight:
+
+```bash
+asc publish testflight --app "APP_ID" --ipa ".asc/artifacts/App.ipa" --group "GROUP_ID" --wait
+```
+
+Publish to the App Store:
+
+```bash
+asc publish appstore --app "APP_ID" --ipa ".asc/artifacts/App.ipa" --version "1.2.3" --wait
+asc publish appstore --app "APP_ID" --ipa ".asc/artifacts/App.ipa" --version "1.2.3" --wait --submit --confirm
+```
+
+## macOS App Store flow
+
+Archive with the helper:
+
+```bash
+asc xcode archive \
+  --project "MacApp.xcodeproj" \
+  --scheme "MacApp" \
+  --configuration Release \
+  --clean \
+  --archive-path ".asc/artifacts/MacApp.xcarchive" \
+  --xcodebuild-flag=-destination \
+  --xcodebuild-flag=generic/platform=macOS \
+  --output json
+```
+
+If your macOS export produces a `.pkg`, use Xcode export with your `ExportOptions.plist`, then upload the package:
+
 ```bash
 xcodebuild -exportArchive \
-  -archivePath /tmp/YourApp.xcarchive \
-  -exportPath /tmp/YourAppExport \
-  -exportOptionsPlist ExportOptions.plist \
+  -archivePath ".asc/artifacts/MacApp.xcarchive" \
+  -exportPath ".asc/artifacts/MacAppExport" \
+  -exportOptionsPlist "ExportOptions.plist" \
   -allowProvisioningUpdates
-```
 
-A minimal `ExportOptions.plist` for App Store distribution:
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>method</key>
-    <string>app-store-connect</string>
-    <key>teamID</key>
-    <string>YOUR_TEAM_ID</string>
-</dict>
-</plist>
-```
-
-### 3. Upload with asc
-```bash
-asc builds upload --app "APP_ID" --ipa "/tmp/YourAppExport/YourApp.ipa"
-```
-
-## macOS Build Flow
-
-### 1. Archive
-```bash
-xcodebuild archive \
-  -scheme "YourMacScheme" \
-  -configuration Release \
-  -archivePath /tmp/YourMacApp.xcarchive \
-  -destination "generic/platform=macOS"
-```
-
-### 2. Export PKG
-```bash
-xcodebuild -exportArchive \
-  -archivePath /tmp/YourMacApp.xcarchive \
-  -exportPath /tmp/YourMacAppExport \
-  -exportOptionsPlist ExportOptions.plist \
-  -allowProvisioningUpdates
-```
-
-### 3. Upload PKG with asc
-macOS apps export as `.pkg` files. Upload with `asc`:
-```bash
 asc builds upload \
   --app "APP_ID" \
-  --pkg "/tmp/YourMacAppExport/YourApp.pkg" \
+  --pkg ".asc/artifacts/MacAppExport/MacApp.pkg" \
   --version "1.0.0" \
-  --build-number "123"
+  --build-number "123" \
+  --wait
 ```
 
-Notes:
-- `--pkg` automatically sets platform to `MAC_OS`.
-- For `.pkg` uploads, `--version` and `--build-number` are required (they are not auto-extracted like IPA uploads).
-- Add `--wait` if you want to wait for build processing to complete.
+For `.pkg` uploads, `--version` and `--build-number` are required because they are not auto-extracted like IPA metadata.
 
-## Build Number Management
+## Raw xcodebuild fallback
 
-Each upload requires a unique build number higher than previously uploaded builds.
+Use raw `xcodebuild` only when `asc xcode archive/export --help` does not cover a project-specific option. Prefer passing extra arguments through `--xcodebuild-flag` first.
 
-In Xcode project settings:
-- `CURRENT_PROJECT_VERSION` - build number (e.g., "316")
-- `MARKETING_VERSION` - version string (e.g., "2.2.0")
-
-Check existing builds:
 ```bash
-asc builds list --app "APP_ID" --platform IOS --limit 5
+xcodebuild -showBuildSettings -scheme "App"
 ```
 
 ## Troubleshooting
 
-### "No profiles for bundle ID" during export
-- Add `-allowProvisioningUpdates` flag
-- Verify your Apple ID is logged into Xcode
+### No profiles for bundle ID during export
 
-### Build rejected for missing icon (macOS)
-macOS requires ICNS format icons with all sizes:
-- 16x16, 32x32, 128x128, 256x256, 512x512 (1x and 2x)
+- Add `--xcodebuild-flag=-allowProvisioningUpdates` to `asc xcode export`.
+- Verify the Apple ID is logged into Xcode.
+- Verify profiles with the `asc-signing-setup` skill.
 
 ### CFBundleVersion too low
-The build number must be higher than any previously uploaded build. Increment it with `asc xcode version bump --type build`, or resolve a remote-safe number with `asc builds next-build-number --app "APP_ID" --version "2.2.0" --platform IOS` and then apply it with `asc xcode version edit --build-number "NEXT_BUILD"` before rebuilding.
+
+```bash
+asc builds next-build-number --app "APP_ID" --version "1.2.3" --platform IOS
+asc xcode version edit --build-number "NEXT_BUILD"
+```
+
+Then rebuild and upload again.
+
+### Build rejected for missing macOS icon
+
+macOS requires ICNS icons with all required sizes. Fix the asset catalog, rebuild, then export/upload again.
 
 ## Notes
-- Always clean before archive for release builds
-- Use `xcodebuild -showBuildSettings` to verify configuration
-- For submission issues (encryption, content rights), see `asc-submission-health` skill
+
+- Prefer `asc xcode archive` and `asc xcode export` for deterministic local artifacts.
+- Use `--overwrite` only when replacing existing local artifacts intentionally.
+- Use `--wait` on upload/publish paths when the next step depends on processed builds.
+- For submission readiness, use `asc-submission-health`.


### PR DESCRIPTION
## Summary

Updates the stale App Store Connect CLI skills called out in the audit so their examples and guidance match the current `asc` command surface.

## Changes

- Refreshes `asc-metadata-sync` around the canonical `asc metadata pull/validate/push/apply` workflow and explicit version selectors for quick edits.
- Replaces removed release/submission guidance with `asc validate`, `asc release stage`, `asc review submit`, and `asc publish appstore --submit --confirm`.
- Moves screenshot resizing guidance to derive dimensions from `asc screenshots sizes --all` instead of a static table.
- Updates workflow examples for current release commands, step outputs, and `--resume`.
- Updates Xcode build guidance to prefer `asc xcode archive` and `asc xcode export` over raw `xcodebuild` recipes.
- Updates the README release-flow summary.

## Validation

- `git diff --check`
- stale removed-command scan across `skills` and `README.md`
- verified updated command paths against `/tmp/asc-current --help`
- `asc screenshots sizes --all --output json` smoke check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated App Store release workflow guidance to emphasize validation and staging before submission.
  * Reorganized metadata synchronization documentation with new canonical procedures.
  * Revised screenshot resize guidance to prioritize CLI-based dimension discovery.
  * Expanded submission health and readiness checklist with updated command recommendations.
  * Clarified workflow automation documentation for local automations.
  * Standardized Xcode build and export workflow guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->