### PR TITLE
Add Apple Ads agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # asc cli skills
 
-A collection of Agent Skills for shipping with the [asc cli](https://github.com/rorkai/App-Store-Connect-CLI) (`asc`). These skills are designed for zero-friction automation around builds, TestFlight, metadata, submissions, and signing.
+A collection of Agent Skills for shipping with the [asc cli](https://github.com/rorkai/App-Store-Connect-CLI) (`asc`). These skills help agents run builds, TestFlight, metadata, submissions, signing, and Apple Ads workflows.
 
 This is a community-maintained, unofficial skill pack and is not affiliated with Apple.
 
@@ -29,11 +29,27 @@ Guidance for running `asc` commands (canonical verbs, flags, pagination, output,
 **Use when:**
 - You need the correct `asc` command or flag combination
 - You want JSON-first output and pagination tips for automation
+- You need Apple Ads command, auth, org, payload, or pagination guidance
 
 **Example:**
 
 ```bash
 Find the right asc command to list all builds for app 123456789 as JSON and paginate through everything.
+```
+
+### asc-apple-ads
+
+Apple Ads auth, org lookup, campaigns, ad groups, ads, keywords, reports, raw API calls, and safe live testing.
+
+**Use when:**
+- You need to read or change Apple Ads resources with `asc ads`
+- You need Apple Ads OAuth, profile, or `ASC_ADS_*` guidance
+- You need a safe read-first plan before mutating a live Ads account
+
+**Example:**
+
+```bash
+Find my Apple Ads org, list campaigns as JSON, create a paused test campaign, and clean it up after verification.
 ```
 
 ### asc-workflow

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Apple Ads auth, org lookup, campaigns, ad groups, ads, keywords, reports, raw AP
 **Example:**
 
 ```bash
-Find my Apple Ads org, list campaigns as JSON, create a paused test campaign, and clean it up after verification.
+Find my Apple Ads org, list campaigns as JSON, and draft a safe plan before creating any test campaign.
 ```
 
 ### asc-workflow

--- a/skills/asc-apple-ads/SKILL.md
+++ b/skills/asc-apple-ads/SKILL.md
@@ -136,7 +136,7 @@ asc ads targeting-keywords delete-bulk \
 asc ads campaigns delete --org "123456" --campaign 987654321 --confirm
 ```
 
-For live tests, create paused resources with names such as `ASC CLI Live Test <timestamp>`. Clean up by deleting the parent campaign. Apple may reject direct deletion for default product page creative ads, but deleting the parent campaign or ad group can clean up the test resource.
+For live tests, create paused resources with names such as `ASC CLI Live Test <timestamp>`. Clean up only the parent campaign or ad group created for that test. Apple may reject direct deletion for default product page creative ads, but deleting the test parent campaign or ad group can clean up the test resource.
 
 ## Raw API
 
@@ -160,5 +160,5 @@ Raw requests accept only Apple Ads v5 paths or `https://api.searchads.apple.com/
 - Create paused or future-dated resources.
 - Use a unique test name.
 - Save created IDs from JSON output.
-- Delete the parent campaign at the end.
+- Delete only the test parent campaign or ad group created during the run.
 - Run a final campaigns find/list query to confirm cleanup.

--- a/skills/asc-apple-ads/SKILL.md
+++ b/skills/asc-apple-ads/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: asc-apple-ads
+description: Use when managing Apple Ads with asc, including auth, org lookup, campaigns, ad groups, ads, keywords, reports, raw API calls, and safe live testing.
+---
+
+# asc Apple Ads
+
+Use this skill when a task involves Apple Ads or `asc ads`.
+
+## Ground Rules
+- Run `asc ads --help` or the specific subgroup help before scripting a command.
+- Apple Ads auth is separate from App Store Connect auth. `asc auth login` does not configure `asc ads`.
+- Use JSON output for automation: `--output json`.
+- Most commands need an org ID. Prefer `--org` for one-off commands and `ASC_ADS_ORG_ID` for a scoped session.
+- Never guess payload fields. Use Apple Ads request JSON in a file and pass it with `--file`.
+- Do not mutate a live account until the user has named the org and approved the resource type. Prefer read-only checks first.
+
+## Auth
+
+Stored profile:
+
+```bash
+asc ads auth login \
+  --name "Marketing" \
+  --client-id "$ASC_ADS_CLIENT_ID" \
+  --team-id "$ASC_ADS_TEAM_ID" \
+  --key-id "$ASC_ADS_KEY_ID" \
+  --private-key "$ASC_ADS_PRIVATE_KEY_PATH" \
+  --org "$ASC_ADS_ORG_ID" \
+  --network
+```
+
+Environment auth:
+
+```bash
+export ASC_ADS_CLIENT_ID="SEARCHADS_CLIENT_ID"
+export ASC_ADS_TEAM_ID="SEARCHADS_TEAM_ID"
+export ASC_ADS_KEY_ID="KEY_ID"
+export ASC_ADS_PRIVATE_KEY_PATH="$HOME/.asc/apple-ads-private-key.pem"
+export ASC_ADS_ORG_ID="123456"
+```
+
+Short-lived token auth:
+
+```bash
+export ASC_ADS_ACCESS_TOKEN="ACCESS_TOKEN"
+export ASC_ADS_ORG_ID="123456"
+```
+
+Useful checks:
+
+```bash
+asc ads auth status --validate --output json
+asc ads auth doctor --output json
+asc ads me view --output json
+asc ads acls --output json
+```
+
+## Org Resolution
+
+When the org ID is unknown:
+
+```bash
+asc ads acls --output json
+```
+
+Use the returned org ID:
+
+```bash
+asc ads campaigns --org "123456" --limit 10 --output json
+```
+
+Org precedence is `--org`, `ASC_ADS_ORG_ID`, stored profile `org_id`, then config `ads.org_id`.
+
+## Read Workflows
+
+Campaigns and ad groups:
+
+```bash
+asc ads campaigns --org "123456" --limit 100 --output json
+asc ads campaigns --org "123456" --paginate --output json
+asc ads campaigns view --org "123456" --campaign 987654321 --output json
+asc ads ad-groups list --org "123456" --campaign 987654321 --output json
+```
+
+Discovery:
+
+```bash
+asc ads apps search --org "123456" --query "My App" --limit 10 --output json
+asc ads product-pages list --org "123456" --adam-id 1234567890 --states VISIBLE --output json
+asc ads creatives list --org "123456" --limit 100 --output json
+asc ads geo search --org "123456" --query "San Francisco" --country-code US --limit 10 --output json
+```
+
+Reports:
+
+```bash
+asc ads reports campaigns --org "123456" --file reporting-request.json --output json
+asc ads reports keywords --org "123456" --campaign 987654321 --file reporting-request.json --output json
+```
+
+Reporting and find endpoints keep pagination in the JSON body.
+
+## Mutating Workflows
+
+Create and update commands take Apple Ads JSON files:
+
+```bash
+asc ads campaigns create --org "123456" --file campaign.json --output json
+asc ads campaigns update --org "123456" --campaign 987654321 --file campaign-update.json --output json
+asc ads ad-groups create --org "123456" --campaign 987654321 --file ad-group.json --output json
+```
+
+Bulk endpoints often require arrays:
+
+```bash
+asc ads targeting-keywords create-bulk \
+  --org "123456" \
+  --campaign 987654321 \
+  --ad-group 123456789 \
+  --file keywords.json \
+  --output json
+```
+
+Delete commands require `--confirm`:
+
+```bash
+asc ads targeting-keywords delete-bulk \
+  --org "123456" \
+  --campaign 987654321 \
+  --ad-group 123456789 \
+  --file keyword-ids.json \
+  --confirm \
+  --output json
+
+asc ads campaigns delete --org "123456" --campaign 987654321 --confirm
+```
+
+For live tests, create paused resources with names such as `ASC CLI Live Test <timestamp>`. Clean up by deleting the parent campaign. Apple may reject direct deletion for default product page creative ads, but deleting the parent campaign or ad group can clean up the test resource.
+
+## Raw API
+
+Use raw requests when Apple adds a field before the first-class command surface changes:
+
+```bash
+asc ads api request \
+  --method POST \
+  --path v5/campaigns/find \
+  --org "123456" \
+  --file selector.json \
+  --output json
+```
+
+Raw requests accept only Apple Ads v5 paths or `https://api.searchads.apple.com/api/v5/...` URLs. `DELETE` still requires `--confirm`.
+
+## Live Test Checklist
+
+- Start with `asc ads me view --output json` and `asc ads acls --output json`.
+- Print the target org ID before mutations.
+- Create paused or future-dated resources.
+- Use a unique test name.
+- Save created IDs from JSON output.
+- Delete the parent campaign at the end.
+- Run a final campaigns find/list query to confirm cleanup.

--- a/skills/asc-cli-usage/SKILL.md
+++ b/skills/asc-cli-usage/SKILL.md
@@ -52,6 +52,16 @@ Use this skill when you need to run or design `asc` commands for App Store Conne
   - This lives under the experimental web auth surface.
   - It can resolve the current local auth by default, or inspect a specific key with `--key-id`.
 
+## Apple Ads
+- Use `asc ads --help` before choosing a command.
+- Apple Ads uses `asc ads auth`, `--ads-profile`, and `ASC_ADS_*` variables. It does not use App Store Connect API credentials.
+- Resolve org access with `asc ads acls --output json` unless the org ID is already known.
+- Most endpoint commands need `--org` or `ASC_ADS_ORG_ID`.
+- Body commands use `--file` with Apple Ads JSON payloads. Object endpoints need a JSON object. Bulk endpoints often need a JSON array.
+- Use `--paginate` only where help shows it. Reporting and selector payloads carry pagination inside the JSON file.
+- Destructive commands and bulk delete commands require `--confirm`.
+- For live mutation tests, create paused resources with a clear test name and delete the parent campaign when done.
+
 ## Timeouts
 - `ASC_TIMEOUT` / `ASC_TIMEOUT_SECONDS` control request timeouts.
 - `ASC_UPLOAD_TIMEOUT` / `ASC_UPLOAD_TIMEOUT_SECONDS` control upload timeouts.


### PR DESCRIPTION
## Summary

- Add `asc-apple-ads` so agents have focused guidance for `asc ads` auth, org lookup, payload files, reporting, raw API calls, and safe live testing.
- Extend `asc-cli-usage` with the Apple Ads auth and pagination rules.
- Update the README skill list with Apple Ads use cases.

## Verification

- Checked all `SKILL.md` frontmatter shape locally.
- `hasp check-repo --project-root /Users/nan/Work/ai/asc-skills --json`
- `npx --yes skills add /Users/nan/Work/ai/asc-skills --help` discovered 23 skills, including `asc-apple-ads`; generated install artifacts were removed from the working tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Apple Ads skill doc covering auth, org lookup, campaign/ad group/ad management, reports, raw API usage, and safe live-testing guidance.
  * Updated README to show support for builds, TestFlight, metadata, submissions, signing, and Apple Ads workflows.
  * Expanded CLI usage docs with Apple Ads command discovery, authentication modes, request-body/pagination guidance, and guarded mutation/delete instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->