### PR TITLE
docs(signing): note profile expiration caveat

### DIFF
--- a/skills/asc-signing-setup/SKILL.md
+++ b/skills/asc-signing-setup/SKILL.md
@@ -41,6 +41,9 @@ Use this skill when you need to create or renew signing assets for iOS/macOS app
 ## Rotation and cleanup
 - Revoke old certificates:
   - `asc certificates revoke --id "CERT_ID" --confirm`
+- Audit remote provisioning profiles before deleting or rotating:
+  - `asc profiles list --profile-state ACTIVE,INVALID --paginate --output json`
+  - Apple `profileState` is not a complete expiration signal: some profiles can have a past `expirationDate` while still reporting `ACTIVE`. For true expired-profile audits, compare `expirationDate` against the current date instead of relying only on `INVALID`.
 - Delete old profiles:
   - `asc profiles delete --id "PROFILE_ID" --confirm`
 - Clean local Xcode provisioning profiles:


### PR DESCRIPTION
## Summary
- add `asc profiles list --profile-state ACTIVE,INVALID --paginate --output json` to signing cleanup guidance
- document that Apple `profileState` is not a complete expiration signal
- tell agents to compare `expirationDate` against the current date for true expired-profile audits

## Why
`asc` 1.9.1 makes invalid provisioning profiles visible, but live ASC data showed some profiles can have a past `expirationDate` while still reporting `ACTIVE`. The skill should steer agents away from treating `INVALID` as synonymous with expired.

## Validation
- documentation-only change
- no package/test harness exists in this skill repo checkout


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated provisioning profile rotation and cleanup procedures with improved auditing steps.
  * Clarified best practices for accurately identifying expired provisioning profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->