### PR TITLE
docs: prefer nested review item commands

### DIFF
--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -221,12 +221,12 @@ If Game Center component versions must ship with the app version, use the explic
 
 ```bash
 asc review submissions-create --app "APP_ID" --platform IOS
-asc review items-add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
-asc review items-add --submission "SUBMISSION_ID" --item-type gameCenterLeaderboardVersions --item-id "GC_LEADERBOARD_VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type gameCenterLeaderboardVersions --item-id "GC_LEADERBOARD_VERSION_ID"
 asc review submissions-submit --id "SUBMISSION_ID" --confirm
 ```
 
-`asc review items-add` also supports `gameCenterAchievementVersions`, `gameCenterActivityVersions`, `gameCenterChallengeVersions`, and `gameCenterLeaderboardSetVersions`.
+`asc review items add` also supports `gameCenterAchievementVersions`, `gameCenterActivityVersions`, `gameCenterChallengeVersions`, and `gameCenterLeaderboardSetVersions`.
 
 ### App Privacy is still unpublished
 

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -171,8 +171,8 @@ Use the lower-level review-submission API when the submission needs multiple rev
 
 ```bash
 asc review submissions-create --app "APP_ID" --platform IOS
-asc review items-add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
-asc review items-add --submission "SUBMISSION_ID" --item-type gameCenterChallengeVersions --item-id "GC_CHALLENGE_VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type gameCenterChallengeVersions --item-id "GC_CHALLENGE_VERSION_ID"
 asc review submissions-submit --id "SUBMISSION_ID" --confirm
 ```
 


### PR DESCRIPTION
## Summary
- Update release/submission skills to prefer the current nested review item command path: `asc review items add`.
- Keep behavior scoped to the 2.5.0 post-release drift found in multi-item review submission examples.

## Evidence
- Latest ASC CLI release inspected: 2.5.0, published 2026-06-28T20:50:07Z.
- Fresh local CLI built from App-Store-Connect-CLI commit 4a71ffe3ff2640fee872633a057c5655797f5c03.
- Verified `asc review items add --help`, `asc review items list --help`, `asc review items update --help`, and `asc review items remove --help` with the fresh binary.
- Confirmed old `asc review items-add` references are removed from the skills.

## Validation
- `git diff --check`
- `/tmp/asc review items add --help`
- `/tmp/asc review items list --help`
- `/tmp/asc review items update --help`
- `/tmp/asc review items remove --help`

## Notes
- No repo-level package/test harness was found in this skills repo, so validation is command-help and markdown-diff based.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command examples to use the current review-item subcommand format.
  * Clarified supported review item types in the release flow guidance.
  * Kept the submission steps unchanged while aligning the examples with the latest syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->