### PR TITLE
Sync skills for asc 2.5.1 web-session promotion

### DIFF
--- a/skills/asc-app-create-ui/SKILL.md
+++ b/skills/asc-app-create-ui/SKILL.md
@@ -100,7 +100,7 @@ asc web apps availability create \
   --available-in-new-territories true
 ```
 
-Use the experimental web flow above only for the first availability bootstrap. If app availability already exists, switch to `asc pricing availability edit --app "APP_ID" ...` for later territory changes.
+Use the web-session flow above only for the first availability bootstrap. If app availability already exists, switch to `asc pricing availability edit --app "APP_ID" ...` for later territory changes.
 
 ## Known UI Automation Issues
 

--- a/skills/asc-cli-usage/SKILL.md
+++ b/skills/asc-cli-usage/SKILL.md
@@ -18,8 +18,9 @@ Use this skill when you need to run or design `asc` commands for App Store Conne
 - Use `asc schema` to inspect bundled App Store Connect endpoint schemas and request/query fields before designing API-facing commands.
   - `asc schema --pretty "GET /v1/apps"`
   - `asc schema --method POST appStoreVersions`
-- Use `asc capabilities` to explain CLI-supported, partial, web-only, and public-API-limited workflow coverage.
+- Use `asc capabilities` to explain CLI-supported, partial, web-session, and public-API-limited workflow coverage.
   - `asc capabilities --area release --output table`
+  - `asc capabilities --status web-session --output table`
   - `asc capabilities --status not-public-api --output markdown`
 
 ## Canonical verbs (current asc)
@@ -49,7 +50,7 @@ Use this skill when you need to run or design `asc` commands for App Store Conne
 - Fallback env vars: `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY_PATH`, `ASC_PRIVATE_KEY`, `ASC_PRIVATE_KEY_B64`.
 - `ASC_APP_ID` can provide a default app ID.
 - When permissions are unclear, inspect exact API key role coverage with `asc web auth capabilities`.
-  - This lives under the experimental web auth surface.
+  - This lives under the web-session auth surface.
   - It can resolve the current local auth by default, or inspect a specific key with `--key-id`.
 
 ## Apple Ads

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -12,7 +12,7 @@ Use this skill when the question is "Can my app be submitted now?" or when the u
 - Resolve `APP_ID`, version string, `VERSION_ID` when needed, and `BUILD_ID` up front.
 - Ensure auth is configured with `asc auth login` or `ASC_*` environment variables.
 - Have canonical metadata in `./metadata` when using metadata-driven staging.
-- Treat `asc web ...` commands as optional experimental escape hatches for flows not covered by the public API.
+- Treat `asc web ...` commands as optional web-session fallbacks for flows not covered by the public API.
 
 ## Answer order
 
@@ -25,7 +25,7 @@ Blockers usually fall into:
 
 - API-fixable: build validity, metadata, screenshots, review details, content rights, encryption, version/build attachment, IAP readiness, Game Center version and review-submission items.
 - Web-session-fixable: initial app availability bootstrap, first-review subscription attachment, App Privacy publish state.
-- Manual fallback: first-time IAP selection on the app-version page when no CLI attach flow exists, or any flow the user does not want to run through experimental web-session commands.
+- Manual fallback: first-time IAP selection on the app-version page when no CLI attach flow exists, or any flow the user does not want to run through web-session commands.
 
 ## Canonical current path
 
@@ -123,7 +123,7 @@ Check:
 asc pricing availability view --app "APP_ID"
 ```
 
-Bootstrap the first availability record with the experimental web-session flow:
+Bootstrap the first availability record with the web-session flow:
 
 ```bash
 asc web apps availability create \
@@ -202,13 +202,13 @@ asc iap submit --iap-id "IAP_ID" --confirm
 
 For the first IAP on an app, or the first time adding a new IAP type, Apple may require selecting the IAP from the app version's "In-App Purchases and Subscriptions" section before submitting the app version. Prepare the IAP with localization, pricing, and review screenshot data first.
 
-For non-renewing IAPs that must be attached to the next app version review, the public API may reject the review item path. The CLI exposes an experimental web-session escape hatch that mirrors the App Store Connect web flow:
+For non-renewing IAPs that must be attached to the next app version review, the public API may reject the review item path. The CLI exposes a web-session fallback that mirrors the App Store Connect web flow:
 
 ```bash
 asc web review iaps attach --app "APP_ID" --iap-id "IAP_ID" --confirm
 ```
 
-Use this only for the web-only first-version selection gap, and call out that it uses unofficial Apple web-session endpoints.
+Use this only for the web-only first-version selection gap, and call out that it requires an authenticated Apple web session.
 
 ### Game Center needs app-version and review-submission items
 
@@ -239,7 +239,7 @@ asc web privacy apply --app "APP_ID" --file "./privacy.json"
 asc web privacy publish --app "APP_ID" --confirm
 ```
 
-If the user avoids experimental web-session commands, confirm App Privacy manually in App Store Connect:
+If the user avoids web-session commands, confirm App Privacy manually in App Store Connect:
 
 ```text
 https://appstoreconnect.apple.com/apps/APP_ID/appPrivacy

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -128,7 +128,7 @@ asc validate subscriptions --app "APP_ID" --output json --pretty
 
 ### 9. App Privacy advisory
 
-The public API cannot fully verify App Privacy publish state. If validation reports an advisory, use the experimental web-session flow or confirm manually.
+The public API cannot fully verify App Privacy publish state. If validation reports an advisory, use the web-session flow or confirm manually.
 
 ```bash
 asc web privacy pull --app "APP_ID" --out "./privacy.json"
@@ -176,13 +176,13 @@ asc review items add --submission "SUBMISSION_ID" --item-type gameCenterChalleng
 asc review submissions-submit --id "SUBMISSION_ID" --confirm
 ```
 
-For non-renewing IAPs that Apple requires to be selected with the next app version, the public API can reject both direct review items and standalone IAP submission. After validating IAP readiness, use the experimental web-session attachment only for that web-only gap:
+For non-renewing IAPs that Apple requires to be selected with the next app version, the public API can reject both direct review items and standalone IAP submission. After validating IAP readiness, use the web-session attachment only for that web-only gap:
 
 ```bash
 asc web review iaps attach --app "APP_ID" --iap-id "IAP_ID" --confirm
 ```
 
-This command uses unofficial Apple web-session endpoints and should be documented in the handoff.
+This command requires an authenticated Apple web session and should be documented in the handoff.
 
 ## Monitor
 


### PR DESCRIPTION
## Summary
- sync skills wording with `asc` `2.5.1` web-session promotion
- replace stale `experimental` / `unofficial` guidance for `asc web` fallback flows
- add the current `asc capabilities --status web-session` example

## Proven drift
`asc 2.5.1` changed the user-facing contract for `asc web`:
- top-level help now shows `WEB SESSION COMMANDS` and `web: Apple web-session workflows`
- `asc web --help` now describes canonical Apple web-session workflows instead of experimental/unofficial/discouraged usage
- `asc capabilities --status web-session` succeeds
- `asc capabilities --status experimental-web` now fails with `invalid --status`

## Skills updated
- `skills/asc-cli-usage/SKILL.md`
- `skills/asc-release-flow/SKILL.md`
- `skills/asc-submission-health/SKILL.md`
- `skills/asc-app-create-ui/SKILL.md`

## Validation
- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2.5.1 capabilities --area release --output table`
- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2.5.1 capabilities --status web-session --output table`
- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2.5.1 capabilities --status not-public-api --output markdown`
- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2.5.1 web auth capabilities --help`
- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2.5.1 web apps availability create --help`
- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2.5.1 pricing availability edit --help`
- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2.5.1 validate subscriptions --help`
- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2.5.1 web review iaps attach --help`
- `ASC_BYPASS_KEYCHAIN=1 /tmp/asc-2.5.1 web privacy publish --help`
- `git diff --check`
- `npx skills --help`
- `npx skills validate --help` -> `Unknown command: validate`

## Notes
- Kept this PR as draft because the local `skills` tool still does not expose a dedicated validator command in this environment.
- Did not touch screenshot-related `experimental` wording because current CLI help still marks local screenshot framing/capture surfaces experimental.
