### PR TITLE
Document Autohand Code skill install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Or install directly from GitHub:
 npx skills add rorkai/app-store-connect-cli-skills
 ```
 
+For Autohand Code, copy the skills you need into the current project:
+
+```bash
+mkdir -p .autohand/skills
+cp -R skills/asc-cli-usage .autohand/skills/
+```
+
+Autohand Code user skills live under `~/.autohand/skills/`; project skills live
+under `<project>/.autohand/skills/`.
+
 ## Available Skills
 
 ### asc-cli-usage


### PR DESCRIPTION
## Summary
- add a short Autohand Code section for copying skills into a project
- keep the existing asc and skills CLI installation paths unchanged

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup guidance for Autohand Code users to copy the required skills into a project-local `.autohand/skills/` directory.
  * Included a command example for creating the directory and copying the `asc-cli-usage` skill.
  * Clarified the difference between project-level skills and user-level skills for easier setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->