### PR TITLE
docs: sync metadata skill with asc 2.6.1 review flow

### DIFF
--- a/skills/asc-metadata-sync/SKILL.md
+++ b/skills/asc-metadata-sync/SKILL.md
@@ -68,6 +68,17 @@ asc metadata apply --app "APP_ID" --version "1.2.3" --platform IOS --dir "./meta
 asc metadata apply --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
 ```
 
+For a review-artifact workflow with explicit approval before mutation, use the metadata review commands introduced in `asc` 2.6.1:
+
+```bash
+asc metadata plan --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata" --review-dir ".asc/metadata/review"
+asc metadata approve --review-dir ".asc/metadata/review" --all
+asc metadata status --review-dir ".asc/metadata/review" --output table
+asc metadata apply --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata" --review-dir ".asc/metadata/review" --confirm
+```
+
+Use `asc metadata approve --key "version:en-US:whatsNew"` or `--scope app-info,version` when the user wants selective approval artifacts before the guarded apply.
+
 ## Keyword-only workflow
 
 Use this when only the version-localization `keywords` field should change:
@@ -150,6 +161,7 @@ asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir "./fa
 - Start with `asc metadata pull` unless the user specifically asks for `.strings` or fastlane metadata.
 - Always run `asc metadata validate` before remote writes.
 - Preview remote changes with `--dry-run` when the command supports it.
+- Use `asc metadata plan` plus `approve`/`status` when the user wants a durable review artifact before apply.
 - For quick edits, always pass `--version-id` or `--version` plus `--platform`; do not rely on ambiguous latest-version behavior.
 - Keep app-info fields and version fields separate.
 - Use `--output table` for human verification and JSON for automation.


### PR DESCRIPTION
## Summary
- add the `asc metadata` review-artifact workflow introduced in ASC CLI `2.6.1`
- document `plan`, `approve`, and `status`, plus guarded `apply --review-dir --confirm`
- keep the existing plain `push` / `apply` flow unchanged for non-reviewed metadata syncs

## CLI evidence
Verified against `rorkai/App-Store-Connect-CLI` tag `2.6.1` (`c3d49e0fca85bcefb942b73451d12494cd18d401`) with current source help:
- `go run . metadata --help`
- `go run . metadata plan --help`
- `go run . metadata approve --help`
- `go run . metadata status --help`
- `go run . metadata apply --help`

Relevant surface added in `2.6.1`:
- `asc metadata plan`
- `asc metadata approve`
- `asc metadata status`
- `asc metadata apply --review-dir ... --confirm`

## Validation
- Verified all documented command examples above against current source help.
- `npx skills validate skills/asc-metadata-sync/SKILL.md` is not available in this environment because the installed `skills` CLI exposes no `validate` subcommand.

## Notes
- `/opt/homebrew/bin/asc` on this machine is older than `2.6.1`, so PATH help was not used as release truth for the new metadata subcommands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for a review-and-approve workflow for metadata changes, including planning, checking status, and applying approved updates.
  * Documented a safer process for reviewing changes before they are applied, with support for targeted approval using key or scope filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->