### PR TITLE
fix(pricing): align subscription setup guidance

### DIFF
--- a/skills/asc-ppp-pricing/SKILL.md
+++ b/skills/asc-ppp-pricing/SKILL.md
@@ -21,7 +21,7 @@ Prefer the current high-level flows:
 ## Subscription PPP workflow
 
 ### New subscription: bootstrap with `setup`
-Use `setup` when you are creating a new subscription and want to create the group, subscription, first localization, initial price, and availability in one verified flow.
+Use `setup` when you are creating a new subscription and want one verified flow for the group, localizations, App Review screenshot, complete equalized price matrix, and sale availability. The sale territories remain an independently selected subset of the full price matrix.
 
 ```bash
 asc subscriptions setup \
@@ -40,9 +40,10 @@ asc subscriptions setup \
 ```
 
 Notes:
-- `setup` verifies the created state by default.
+- `setup` materializes Apple's complete equalized price matrix from the selected base price, then verifies the final state by default.
 - Use `--no-verify` only when you explicitly want speed over readback verification.
 - Use `--tier` or `--price-point-id` instead of `--price` when your workflow is tier-driven.
+- If an existing subscription remains `MISSING_METADATA` with the same selected base price, re-run the setup inputs with `--repair` to atomically rebuild and re-save the matrix.
 
 ### Inspect current subscription pricing before changes
 Use the summary view first when you want a compact current-state snapshot.
@@ -226,7 +227,7 @@ For future-dated schedules, expect scheduled changes rather than an immediately 
 
 ## Notes
 - Prefer canonical commands in docs and automation: `asc subscriptions pricing ...`
-- Older `asc subscriptions prices ...` paths still exist, but the canonical pricing family is clearer.
+- `asc subscriptions pricing ...` is the supported subscription pricing family; do not use the removed `asc subscriptions prices ...` path.
 - Prefer canonical IAP commands in docs and automation: `asc iap pricing ...`
 - `asc subscriptions pricing prices import --dry-run` is the safest subscription batch PPP path today.
 - `asc subscriptions setup` and `asc iap setup` already provide built-in post-create verification.


### PR DESCRIPTION
## Evidence

Verified against released `asc` 2.8.2 (`d445c4d27404596531949d28e3a4d18482178bd8`):

- `asc subscriptions setup --help` documents complete equalized price-matrix materialization, independent sale availability, and `--repair` for same-price `MISSING_METADATA` repair.
- `asc subscriptions pricing prices set --help` documents `--force` matrix repair.
- `asc subscriptions prices --help` exits 2 with `unexpected argument(s): prices`; the old path is removed.
- `asc validate subscriptions --help` documents complete price-matrix validation.

## Changes

- Align `asc-ppp-pricing` setup guidance with the complete equalized price matrix and `--repair`.
- Remove the claim that `asc subscriptions prices ...` still exists.

## Validation

- Released 2.8.2 built binary: command help checks above.
- `git diff --check`
- `skill-creator` quick validator could not run: its Python interpreter lacks `PyYAML` (`ModuleNotFoundError: yaml`).

This remains draft because the installed skill validator could not execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the subscription pricing setup workflow, including generated price matrices and independently selected sale territories.
  * Documented default verification behavior and guidance for using `--no-verify`.
  * Added remediation guidance for subscriptions stuck in `MISSING_METADATA`.
  * Updated command guidance to use the supported pricing command family.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->