### PR TITLE
Sync availability skills with ASC 3.0.0

### DIFF
--- a/skills/asc-app-create-ui/SKILL.md
+++ b/skills/asc-app-create-ui/SKILL.md
@@ -94,13 +94,14 @@ asc apps list --bundle-id "com.example.app" --output json
 ```bash
 asc app-setup info set --app "APP_ID" --primary-locale "en-US"
 asc app-setup categories set --app "APP_ID" --primary GAMES
-asc web apps availability create \
+asc pricing availability create \
   --app "APP_ID" \
   --territory "USA,GBR" \
+  --available true \
   --available-in-new-territories true
 ```
 
-Use the web-session flow above only for the first availability bootstrap. If app availability already exists, switch to `asc pricing availability edit --app "APP_ID" ...` for later territory changes.
+Use `asc pricing availability create` only for the first availability bootstrap. If app availability already exists, switch to `asc pricing availability edit --app "APP_ID" ...` for later territory changes.
 
 ## Known UI Automation Issues
 

--- a/skills/asc-cli-usage/SKILL.md
+++ b/skills/asc-cli-usage/SKILL.md
@@ -32,6 +32,8 @@ Use this skill when you need to run or design `asc` commands for App Store Conne
   - `asc pricing availability edit --app "APP_ID" --territory "USA,GBR" --available true`
   - `asc app-setup availability edit --app "APP_ID" --territory "USA,GBR" --available true`
   - `asc xcode version edit --build-number "42"`
+- Use `asc pricing availability create` to initialize app availability before using the update-only `edit` command.
+  - `asc pricing availability create --app "APP_ID" --territory "USA,GBR" --available true --available-in-new-territories true`
 - Keep `set` where the CLI intentionally models a higher-level replacement/configuration flow and `--help` still shows `set` as the canonical verb.
 
 ## Flag conventions

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -24,7 +24,7 @@ Use this skill when the question is "Can my app be submitted now?" or when the u
 Blockers usually fall into:
 
 - API-fixable: build validity, metadata, screenshots, review details, content rights, encryption, version/build attachment, IAP readiness, Game Center version and review-submission items.
-- Web-session-fixable: initial app availability bootstrap, first-review subscription attachment, App Privacy publish state.
+- Web-session-fixable: first-review subscription attachment and App Privacy publish state.
 - Manual fallback: first-time IAP selection on the app-version page when no CLI attach flow exists, or any flow the user does not want to run through web-session commands.
 
 ## Canonical current path
@@ -123,12 +123,13 @@ Check:
 asc pricing availability view --app "APP_ID"
 ```
 
-Bootstrap the first availability record with the web-session flow:
+Bootstrap the first availability record through the public API:
 
 ```bash
-asc web apps availability create \
+asc pricing availability create \
   --app "APP_ID" \
   --territory "USA,GBR" \
+  --available true \
   --available-in-new-territories true
 ```
 


### PR DESCRIPTION
## Summary

- replace the web-session fallback for initial app availability with the new public-API `asc pricing availability create` command
- add the required `--available` flag to first-time availability examples
- document the create-before-edit lifecycle in the canonical CLI usage skill

## Why

ASC CLI 3.0.0 added public-API support for initializing app availability. The skills still classified the first availability record as web-session-only and directed agents to `asc web apps availability create`.

Evidence:

- ASC release: `3.0.0`
- ASC release commit: `839c4da6db3678ecbab5cf1db6d78b4b8c486957`
- skills base commit: `0ae3da2bf0a43300d3c994593f4df73f3e3da230`
- `asc pricing availability create --help` requires `--app`, `--territory`, `--available`, and `--available-in-new-territories`
- `asc pricing availability edit --help` explicitly directs missing records to `asc pricing availability create`

## Validation

- built ASC 3.0.0 from tag and confirmed `asc version`
- checked 612 skill command references against 1,595 registered 3.0.0 command paths; no unsupported flags found
- ran `quick_validate.py` successfully for all three changed skill folders
- `git diff --check`

No live App Store Connect mutations were performed.
