### PR TITLE
docs: sync skills with ASC API 4.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,11 @@ Set up signing for com.example.app with iCloud enabled, a distribution certifica
 
 ### asc-id-resolver
 
-Resolve IDs for apps, builds, versions, groups, and testers.
+Resolve IDs for apps, builds, app and digital-goods versions, groups, and testers.
 
 **Use when:**
 - A command requires IDs and you only have names
+- You need an API 4.4.1 IAP, subscription, or subscription-group version ID
 - You want deterministic outputs for automation
 
 **Example:**
@@ -278,7 +279,8 @@ Update my subscription pricing for India, Brazil, and Mexico using a PPP-style r
 
 ### asc-subscription-localization
 
-Bulk-localize subscription and IAP display names across all App Store locales.
+Bulk-localize subscription and IAP display names across all App Store locales,
+including API 4.4.1 version-scoped v2 resources.
 
 **Use when:**
 - You want to set the same subscription display name in every language at once

--- a/skills/asc-id-resolver/SKILL.md
+++ b/skills/asc-id-resolver/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asc-id-resolver
-description: Resolve App Store Connect IDs (apps, builds, versions, groups, testers) from human-friendly names using asc. Use when commands require IDs.
+description: Resolve App Store Connect IDs (apps, builds, app and digital-goods versions, groups, testers) from human-friendly names using asc. Use when commands require IDs.
 ---
 
 # asc id resolver
@@ -24,6 +24,19 @@ Use this skill to map names to IDs needed by other commands.
 
 ## Version ID
 - `asc versions list --app "APP_ID" --paginate`
+
+## Digital-goods version IDs
+
+API 4.4.1 version IDs are distinct from IAP product, subscription, and
+subscription-group IDs:
+
+- IAP versions: `asc iap versions list --iap-id "IAP_ID" --paginate`
+- Subscription versions: `asc subscriptions versions list --subscription-id "SUB_ID" --paginate`
+- Subscription group versions: `asc subscriptions groups versions list --group-id "GROUP_ID" --paginate`
+
+Resolve child localization or image IDs from the corresponding version subtree:
+
+- `asc subscriptions versions localizations list --version-id "VERSION_ID" --paginate`
 
 ## TestFlight IDs
 - Groups:

--- a/skills/asc-id-resolver/SKILL.md
+++ b/skills/asc-id-resolver/SKILL.md
@@ -30,13 +30,28 @@ Use this skill to map names to IDs needed by other commands.
 API 4.4.1 version IDs are distinct from IAP product, subscription, and
 subscription-group IDs:
 
-- IAP versions: `asc iap versions list --iap-id "IAP_ID" --paginate`
-- Subscription versions: `asc subscriptions versions list --subscription-id "SUB_ID" --paginate`
-- Subscription group versions: `asc subscriptions groups versions list --group-id "GROUP_ID" --paginate`
+Resolve the owning resources first:
+
+- IAPs: `asc iap list --app "APP_ID" --paginate --output json`
+- Subscription groups: `asc subscriptions groups list --app "APP_ID" --paginate --output json`
+- Subscriptions: `asc subscriptions list --app "APP_ID" --paginate --output json`
+  or `asc subscriptions list --group-id "GROUP_ID" --paginate --output json`
+
+Then resolve their version IDs:
+
+- IAP versions: `asc iap versions list --iap-id "IAP_ID" --paginate --output json`
+- Subscription versions: `asc subscriptions versions list --subscription-id "SUB_ID" --paginate --output json`
+- Subscription group versions: `asc subscriptions groups versions list --group-id "GROUP_ID" --paginate --output json`
 
 Resolve child localization or image IDs from the corresponding version subtree:
 
-- `asc subscriptions versions localizations list --version-id "VERSION_ID" --paginate`
+- IAP localizations: `asc iap versions localizations list --version-id "VERSION_ID" --paginate --output json`
+- IAP primary image: `asc iap versions image --version-id "VERSION_ID" --output json`
+- IAP image collection: `asc iap versions images list --version-id "VERSION_ID" --paginate --output json`
+- Subscription localizations: `asc subscriptions versions localizations list --version-id "VERSION_ID" --paginate --output json`
+- Subscription primary image: `asc subscriptions versions images primary --version-id "VERSION_ID" --output json`
+- Subscription image collection: `asc subscriptions versions images list --version-id "VERSION_ID" --paginate --output json`
+- Subscription-group localizations: `asc subscriptions groups versions localizations list --version-id "VERSION_ID" --paginate --output json`
 
 ## TestFlight IDs
 - Groups:
@@ -51,7 +66,10 @@ Resolve child localization or image IDs from the corresponding version subtree:
 - `asc review submissions-list --app "APP_ID" --paginate`
 
 ## Output tips
-- JSON is default; use `--pretty` for debug.
+- Output defaults are TTY-aware: table in a terminal and minified JSON in pipes
+  or CI. An explicit `--output` wins.
+- Use explicit `--output json` for automation and add `--pretty` only for
+  human-readable JSON.
 - For human viewing, use `--output table` or `--output markdown`.
 
 ## Guardrails

--- a/skills/asc-ppp-pricing/SKILL.md
+++ b/skills/asc-ppp-pricing/SKILL.md
@@ -49,10 +49,12 @@ v1 localizations, the parent can remain `MISSING_METADATA` until the v2 steps
 finish.
 
 ```bash
+asc subscriptions groups versions list --group-id "GROUP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc subscriptions groups versions create --group-id "GROUP_ID" --output json
 # Capture .data.id as GROUP_VERSION_ID.
 asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Pro"
 
+asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc subscriptions versions create --subscription-id "SUB_ID" --output json
 # Capture .data.id as SUBSCRIPTION_VERSION_ID.
 asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Pro Monthly" --description "Unlock everything"
@@ -60,6 +62,11 @@ asc subscriptions groups versions localizations list --version-id "GROUP_VERSION
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
 asc validate subscriptions --app "APP_ID" --output table
 ```
+
+For each version list, reuse its single `PREPARE_FOR_SUBMISSION` result. Create
+only when the result is empty; if more than one result is returned, stop and
+require an explicit version ID instead of creating another non-deletable
+version.
 
 Notes:
 - `setup` materializes Apple's complete equalized price matrix from the selected
@@ -196,10 +203,14 @@ asc iap setup \
 Capture `.iapId` from the setup JSON, then create the version and metadata:
 
 ```bash
+asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc iap versions create --iap-id "IAP_ID" --output json
 # Capture .data.id as IAP_VERSION_ID.
 asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Pro Lifetime" --description "Unlock everything forever"
 ```
+
+Reuse the single `PREPARE_FOR_SUBMISSION` version. Create only when the list is
+empty, and stop for an explicit version ID if multiple matches are returned.
 
 Notes:
 - `setup` verifies the created IAP and price schedule by default; verify the

--- a/skills/asc-ppp-pricing/SKILL.md
+++ b/skills/asc-ppp-pricing/SKILL.md
@@ -116,7 +116,15 @@ Use price-point lookup and equalizations when you want to inspect Apple's locali
 ```bash
 asc subscriptions pricing price-points list --subscription-id "SUB_ID" --territory "USA" --paginate --price "9.99"
 asc subscriptions pricing price-points equalizations --price-point-id "PRICE_POINT_ID" --paginate
+asc subscriptions pricing price-points adjusted-equalizations --price-point-id "PRICE_POINT_ID" --subscription-id "SUB_ID" --plan-type MONTHLY --paginate
 ```
+
+Use `equalizations` for Apple's standard localized ladder. Use
+`adjusted-equalizations` when you need the API 4.4.1 subscription-specific
+adjustments, optionally filtered by `--subscription-id`, `--territory`,
+`--plan-type MONTHLY`, or `--upfront-price-point-id`. Treat `--next` as an
+opaque continuation URL: do not combine it with filters, sparse fields,
+includes, or limits.
 
 ### Verify after apply
 Re-run the summary and raw list views after changes.

--- a/skills/asc-ppp-pricing/SKILL.md
+++ b/skills/asc-ppp-pricing/SKILL.md
@@ -123,8 +123,10 @@ Use `equalizations` for Apple's standard localized ladder. Use
 `adjusted-equalizations` when you need the API 4.4.1 subscription-specific
 adjustments, optionally filtered by `--subscription-id`, `--territory`,
 `--plan-type MONTHLY`, or `--upfront-price-point-id`. Treat `--next` as an
-opaque continuation URL: do not combine it with filters, sparse fields,
-includes, or limits.
+opaque continuation URL. On a resumed equalizations request, pass `--next`
+without the original owner `--price-point-id`, filters, sparse fields, includes,
+or limit; the continuation URL already carries that query state. `--paginate`
+and explicit output flags may still be used.
 
 ### Verify after apply
 Re-run the summary and raw list views after changes.

--- a/skills/asc-ppp-pricing/SKILL.md
+++ b/skills/asc-ppp-pricing/SKILL.md
@@ -51,13 +51,17 @@ finish.
 ```bash
 asc subscriptions groups versions list --group-id "GROUP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc subscriptions groups versions create --group-id "GROUP_ID" --output json
-# Capture .data.id as GROUP_VERSION_ID.
+# Capture GROUP_VERSION_ID from list .data[0].id or create .data.id.
+asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output json
 asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Pro"
+asc subscriptions groups versions localizations update --id "GROUP_LOC_ID" --name "Pro"
 
 asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc subscriptions versions create --subscription-id "SUB_ID" --output json
-# Capture .data.id as SUBSCRIPTION_VERSION_ID.
+# Capture SUBSCRIPTION_VERSION_ID from list .data[0].id or create .data.id.
+asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
 asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Pro Monthly" --description "Unlock everything"
+asc subscriptions versions localizations update --id "SUBSCRIPTION_LOC_ID" --name "Pro Monthly" --description "Unlock everything"
 asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
 asc validate subscriptions --app "APP_ID" --output table
@@ -66,7 +70,9 @@ asc validate subscriptions --app "APP_ID" --output table
 For each version list, reuse its single `PREPARE_FOR_SUBMISSION` result. Create
 only when the result is empty; if more than one result is returned, stop and
 require an explicit version ID instead of creating another non-deletable
-version.
+version. Each localization create/update pair is also conditional: create for
+a missing locale, update the resolved localization only when values differ,
+and do nothing when it already matches.
 
 Notes:
 - `setup` materializes Apple's complete equalized price matrix from the selected
@@ -205,12 +211,16 @@ Capture `.iapId` from the setup JSON, then create the version and metadata:
 ```bash
 asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc iap versions create --iap-id "IAP_ID" --output json
-# Capture .data.id as IAP_VERSION_ID.
+# Capture IAP_VERSION_ID from list .data[0].id or create .data.id.
+asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output json
 asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Pro Lifetime" --description "Unlock everything forever"
+asc iap versions localizations update --localization-id "IAP_LOC_ID" --name "Pro Lifetime" --description "Unlock everything forever"
 ```
 
 Reuse the single `PREPARE_FOR_SUBMISSION` version. Create only when the list is
 empty, and stop for an explicit version ID if multiple matches are returned.
+Create the localization only when `en-US` is absent, update its resolved ID only
+when values differ, and otherwise do nothing.
 
 Notes:
 - `setup` verifies the created IAP and price schedule by default; verify the

--- a/skills/asc-ppp-pricing/SKILL.md
+++ b/skills/asc-ppp-pricing/SKILL.md
@@ -50,18 +50,26 @@ finish.
 
 ```bash
 asc subscriptions groups versions list --group-id "GROUP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+# If and only if the list has zero matches:
 asc subscriptions groups versions create --group-id "GROUP_ID" --output json
-# Capture GROUP_VERSION_ID from list .data[0].id or create .data.id.
+# For one match, reuse .data[0].id. For more than one, stop and require an explicit GROUP_VERSION_ID.
 asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output json
+# If and only if en-US is missing:
 asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Pro"
+# Otherwise, if and only if the resolved en-US name differs:
 asc subscriptions groups versions localizations update --id "GROUP_LOC_ID" --name "Pro"
+# Otherwise, do nothing.
 
 asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+# If and only if the list has zero matches:
 asc subscriptions versions create --subscription-id "SUB_ID" --output json
-# Capture SUBSCRIPTION_VERSION_ID from list .data[0].id or create .data.id.
+# For one match, reuse .data[0].id. For more than one, stop and require an explicit SUBSCRIPTION_VERSION_ID.
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
+# If and only if en-US is missing:
 asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Pro Monthly" --description "Unlock everything"
+# Otherwise, if and only if the resolved en-US values differ:
 asc subscriptions versions localizations update --id "SUBSCRIPTION_LOC_ID" --name "Pro Monthly" --description "Unlock everything"
+# Otherwise, do nothing.
 asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
 asc validate subscriptions --app "APP_ID" --output table
@@ -210,11 +218,15 @@ Capture `.iapId` from the setup JSON, then create the version and metadata:
 
 ```bash
 asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+# If and only if the list has zero matches:
 asc iap versions create --iap-id "IAP_ID" --output json
-# Capture IAP_VERSION_ID from list .data[0].id or create .data.id.
+# For one match, reuse .data[0].id. For more than one, stop and require an explicit IAP_VERSION_ID.
 asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output json
+# If and only if en-US is missing:
 asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Pro Lifetime" --description "Unlock everything forever"
+# Otherwise, if and only if the resolved en-US values differ:
 asc iap versions localizations update --localization-id "IAP_LOC_ID" --name "Pro Lifetime" --description "Unlock everything forever"
+# Otherwise, do nothing.
 ```
 
 Reuse the single `PREPARE_FOR_SUBMISSION` version. Create only when the list is

--- a/skills/asc-ppp-pricing/SKILL.md
+++ b/skills/asc-ppp-pricing/SKILL.md
@@ -8,7 +8,8 @@ description: Set territory-specific pricing for subscriptions and in-app purchas
 Use this skill to create or update localized pricing across territories based on purchasing power parity (PPP) or your own regional pricing strategy.
 
 Prefer the current high-level flows:
-- `asc subscriptions setup` and `asc iap setup` when you are creating a new product
+- `asc subscriptions setup` and `asc iap setup` for parent creation and pricing,
+  followed by version-scoped metadata commands
 - `asc subscriptions pricing ...` for subscription pricing changes
 - `asc iap pricing summary` and `asc iap pricing schedules ...` for IAP pricing changes
 
@@ -20,8 +21,12 @@ Prefer the current high-level flows:
 
 ## Subscription PPP workflow
 
-### New subscription: bootstrap with `setup`
-Use `setup` when you are creating a new subscription and want one verified flow for the group, localizations, App Review screenshot, complete equalized price matrix, and sale availability. The sale territories remain an independently selected subset of the full price matrix.
+### New subscription: bootstrap the parent and price with `setup`
+Use `setup` to create the group and subscription, upload the App Review
+screenshot, materialize the complete equalized price matrix, and set sale
+availability. Create the API 4.4.1 group and subscription versions afterward;
+the localization flags on `setup` use deprecated v1 resources and must not be
+used for new workflows.
 
 ```bash
 asc subscriptions setup \
@@ -30,18 +35,38 @@ asc subscriptions setup \
   --reference-name "Pro Monthly" \
   --product-id "com.example.pro.monthly" \
   --subscription-period ONE_MONTH \
-  --locale "en-US" \
-  --display-name "Pro Monthly" \
-  --description "Unlock everything" \
+  --review-screenshot "./review.png" \
   --price "9.99" \
   --price-territory "USA" \
   --territories "USA,CAN,GBR" \
+  --no-verify \
   --output json
 ```
 
+Capture `.groupId` and `.subscriptionId` from the setup JSON, then add
+version-scoped metadata. `--no-verify` is intentional here: without deprecated
+v1 localizations, the parent can remain `MISSING_METADATA` until the v2 steps
+finish.
+
+```bash
+asc subscriptions groups versions create --group-id "GROUP_ID" --output json
+# Capture .data.id as GROUP_VERSION_ID.
+asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Pro"
+
+asc subscriptions versions create --subscription-id "SUB_ID" --output json
+# Capture .data.id as SUBSCRIPTION_VERSION_ID.
+asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Pro Monthly" --description "Unlock everything"
+asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
+asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
+asc validate subscriptions --app "APP_ID" --output table
+```
+
 Notes:
-- `setup` materializes Apple's complete equalized price matrix from the selected base price, then verifies the final state by default.
-- Use `--no-verify` only when you explicitly want speed over readback verification.
+- `setup` materializes Apple's complete equalized price matrix from the selected
+  base price. This split workflow defers final verification until the v2
+  localizations exist.
+- Outside this split v2 bootstrap, omit `--no-verify` so setup performs its
+  normal readback verification.
 - Use `--tier` or `--price-point-id` instead of `--price` when your workflow is tier-driven.
 - If an existing subscription remains `MISSING_METADATA` with the same selected base price, re-run the setup inputs with `--repair` to atomically rebuild and re-save the matrix.
 
@@ -116,17 +141,18 @@ Use price-point lookup and equalizations when you want to inspect Apple's locali
 ```bash
 asc subscriptions pricing price-points list --subscription-id "SUB_ID" --territory "USA" --paginate --price "9.99"
 asc subscriptions pricing price-points equalizations --price-point-id "PRICE_POINT_ID" --paginate
-asc subscriptions pricing price-points adjusted-equalizations --price-point-id "PRICE_POINT_ID" --subscription-id "SUB_ID" --plan-type MONTHLY --paginate
+asc subscriptions pricing price-points adjusted-equalizations --price-point-id "PRICE_POINT_ID" --upfront-price-point-id "UPFRONT_PRICE_POINT_ID" --plan-type MONTHLY --subscription-id "SUB_ID" --paginate
 ```
 
 Use `equalizations` for Apple's standard localized ladder. Use
 `adjusted-equalizations` when you need the API 4.4.1 subscription-specific
-adjustments, optionally filtered by `--subscription-id`, `--territory`,
-`--plan-type MONTHLY`, or `--upfront-price-point-id`. Treat `--next` as an
-opaque continuation URL. On a resumed equalizations request, pass `--next`
-without the original owner `--price-point-id`, filters, sparse fields, includes,
-or limit; the continuation URL already carries that query state. `--paginate`
-and explicit output flags may still be used.
+adjustments. For a fresh adjusted-equalizations request, pass both
+`--upfront-price-point-id` and `--plan-type`; `--subscription-id` and
+`--territory` are optional filters. Treat `--next` as an opaque continuation
+URL. On a resumed `equalizations` or `adjusted-equalizations` request, pass only
+`--next` without the original owner `--price-point-id`, filters, sparse fields,
+includes, or limit; the continuation URL already carries that query state.
+`--paginate` and explicit output flags may still be used.
 
 ### Verify after apply
 Re-run the summary and raw list views after changes.
@@ -137,7 +163,9 @@ asc subscriptions pricing summary --subscription-id "SUB_ID" --territory "BRA"
 asc subscriptions pricing prices list --subscription-id "SUB_ID" --paginate
 ```
 
-If the subscription was newly created, you can also use `asc subscriptions setup` with verification enabled instead of stitching together separate create and pricing steps.
+After the version metadata exists, you may rerun `asc subscriptions setup` with
+verification enabled to recheck the parent, pricing, screenshot, and
+availability state.
 
 ### Subscription availability
 If you need to explicitly enable territories for an existing subscription, use the pricing availability family.
@@ -149,8 +177,10 @@ asc subscriptions pricing availability view --subscription-id "SUB_ID"
 
 ## IAP PPP workflow
 
-### New IAP: bootstrap with `setup`
-Use `setup` when you are creating a new IAP and want to create the product, first localization, and initial price schedule in one verified flow.
+### New IAP: bootstrap the parent and price with `setup`
+Use `setup` to create the product and initial price schedule. Its localization
+flags use the deprecated v1 resource, so add localization through an API 4.4.1
+IAP version after setup.
 
 ```bash
 asc iap setup \
@@ -158,16 +188,22 @@ asc iap setup \
   --type NON_CONSUMABLE \
   --reference-name "Pro Lifetime" \
   --product-id "com.example.pro.lifetime" \
-  --locale "en-US" \
-  --display-name "Pro Lifetime" \
-  --description "Unlock everything forever" \
   --price "9.99" \
   --base-territory "USA" \
   --output json
 ```
 
+Capture `.iapId` from the setup JSON, then create the version and metadata:
+
+```bash
+asc iap versions create --iap-id "IAP_ID" --output json
+# Capture .data.id as IAP_VERSION_ID.
+asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Pro Lifetime" --description "Unlock everything forever"
+```
+
 Notes:
-- `setup` verifies the created IAP, localization, and price schedule by default.
+- `setup` verifies the created IAP and price schedule by default; verify the
+  version localization with its version-scoped list command.
 - Use `--start-date` for scheduled pricing.
 - Use `--tier` or `--price-point-id` when you want deterministic tier- or ID-based setup.
 

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asc-release-flow
-description: Determine whether an app is ready to submit, then drive the current App Store release flow with asc, including validation, staging, review submission, first-time availability, subscriptions, IAP, Game Center, and App Privacy checks.
+description: Determine whether an app is ready to submit, then drive the current App Store release flow with asc, including validation, staging, review submission, first-time availability, versioned subscriptions and IAPs, Game Center, and App Privacy checks.
 ---
 
 # Release flow (readiness-first)
@@ -177,10 +177,28 @@ asc web review subscriptions attach \
   --confirm
 ```
 
-For later reviews, submit subscriptions through the public review path:
+The legacy product-scoped public review shortcut remains available:
 
 ```bash
 asc subscriptions review submit --subscription-id "SUB_ID" --confirm
+```
+
+For an API 4.4.1 subscription version, prepare the version-scoped metadata and
+add that version—not the subscription product—to a review submission:
+
+```bash
+asc subscriptions versions create --subscription-id "SUB_ID"
+asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium" --description "Premium access"
+asc subscriptions versions images upload --version-id "SUBSCRIPTION_VERSION_ID" --file "./review.png"
+asc review items add --submission "SUBMISSION_ID" --item-type subscriptionVersions --item-id "SUBSCRIPTION_VERSION_ID"
+```
+
+Subscription group versions follow the same review-item model:
+
+```bash
+asc subscriptions groups versions create --group-id "GROUP_ID"
+asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Premium"
+asc review items add --submission "SUBMISSION_ID" --item-type subscriptionGroupVersions --item-id "GROUP_VERSION_ID"
 ```
 
 ### In-app purchases need review readiness or first-version inclusion
@@ -195,10 +213,20 @@ Upload missing review screenshots:
 asc iap review-screenshots create --iap-id "IAP_ID" --file "./review.png"
 ```
 
-For IAPs on a published app:
+The legacy product-scoped submission shortcut remains available:
 
 ```bash
 asc iap submit --iap-id "IAP_ID" --confirm
+```
+
+For an API 4.4.1 IAP version, use its version ID throughout the v2 metadata,
+image, and review flow:
+
+```bash
+asc iap versions create --iap-id "IAP_ID"
+asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Premium" --description "Unlock premium features"
+asc iap versions images create --version-id "IAP_VERSION_ID" --file "./review.png"
+asc iap versions submit --version-id "IAP_VERSION_ID" --submission "SUBMISSION_ID" --confirm
 ```
 
 For the first IAP on an app, or the first time adding a new IAP type, Apple may require selecting the IAP from the app version's "In-App Purchases and Subscriptions" section before submitting the app version. Prepare the IAP with localization, pricing, and review screenshot data first.
@@ -224,6 +252,9 @@ If Game Center component versions must ship with the app version, use the explic
 asc review submissions-create --app "APP_ID" --platform IOS
 asc review items add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
 asc review items add --submission "SUBMISSION_ID" --item-type gameCenterLeaderboardVersions --item-id "GC_LEADERBOARD_VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type inAppPurchaseVersions --item-id "IAP_VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type subscriptionVersions --item-id "SUBSCRIPTION_VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type subscriptionGroupVersions --item-id "GROUP_VERSION_ID"
 asc review submissions-submit --id "SUBMISSION_ID" --confirm
 ```
 

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -187,6 +187,7 @@ version-scoped metadata and add that version—not the subscription product—to
 the existing submission:
 
 ```bash
+asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc subscriptions versions create --subscription-id "SUB_ID" --output json
 # Capture .data.id from the create response as SUBSCRIPTION_VERSION_ID.
 asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium" --description "Premium access"
@@ -201,6 +202,7 @@ asc review items add --submission "SUBMISSION_ID" --item-type subscriptionVersio
 Subscription group versions follow the same existing-submission model:
 
 ```bash
+asc subscriptions groups versions list --group-id "GROUP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc subscriptions groups versions create --group-id "GROUP_ID" --output json
 # Capture .data.id from the create response as GROUP_VERSION_ID.
 asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Premium"
@@ -208,6 +210,10 @@ asc subscriptions groups versions view --version-id "GROUP_VERSION_ID" --output 
 asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
 asc review items add --submission "SUBMISSION_ID" --item-type subscriptionGroupVersions --item-id "GROUP_VERSION_ID"
 ```
+
+For each list above, reuse its single `PREPARE_FOR_SUBMISSION` result. Create
+only when the result is empty; if multiple matches are returned, stop and
+require an explicit version ID.
 
 ### In-app purchases need review readiness or first-version inclusion
 
@@ -228,6 +234,7 @@ For an API 4.4.1 IAP version, use its version ID throughout the v2 metadata,
 image, and review flow:
 
 ```bash
+asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc iap versions create --iap-id "IAP_ID" --output json
 # Capture .data.id from the create response as IAP_VERSION_ID.
 asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Premium" --description "Unlock premium features"
@@ -238,6 +245,9 @@ asc iap versions image --version-id "IAP_VERSION_ID" --output table
 asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output table
 asc iap versions submit --version-id "IAP_VERSION_ID" --submission "SUBMISSION_ID" --confirm
 ```
+
+Reuse the single `PREPARE_FOR_SUBMISSION` version. Create only when the list is
+empty, and stop for an explicit version ID if multiple matches are returned.
 
 For the first IAP on an app, or the first time adding a new IAP type, Apple may require selecting the IAP from the app version's "In-App Purchases and Subscriptions" section before submitting the app version. Prepare the IAP with localization, pricing, and review screenshot data first.
 

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -177,14 +177,14 @@ asc web review subscriptions attach \
   --confirm
 ```
 
-The legacy product-scoped public review shortcut remains available:
+The product-scoped `asc subscriptions review submit` shortcut is deprecated.
+Do not build new workflows around it.
 
-```bash
-asc subscriptions review submit --subscription-id "SUB_ID" --confirm
-```
-
-For an API 4.4.1 subscription version, prepare the version-scoped metadata and
-add that version—not the subscription product—to a review submission:
+The API 4.4.1 versioned workflow below is for a subsequent review or another
+existing review submission. It does not replace the web-session flow above for
+attaching a subscription or group to its first review. Prepare the
+version-scoped metadata and add that version—not the subscription product—to
+the existing submission:
 
 ```bash
 asc subscriptions versions create --subscription-id "SUB_ID" --output json
@@ -198,7 +198,7 @@ asc subscriptions versions images list --version-id "SUBSCRIPTION_VERSION_ID" --
 asc review items add --submission "SUBMISSION_ID" --item-type subscriptionVersions --item-id "SUBSCRIPTION_VERSION_ID"
 ```
 
-Subscription group versions follow the same review-item model:
+Subscription group versions follow the same existing-submission model:
 
 ```bash
 asc subscriptions groups versions create --group-id "GROUP_ID" --output json
@@ -221,11 +221,8 @@ Upload missing review screenshots:
 asc iap review-screenshots create --iap-id "IAP_ID" --file "./review.png"
 ```
 
-The legacy product-scoped submission shortcut remains available:
-
-```bash
-asc iap submit --iap-id "IAP_ID" --confirm
-```
+The product-scoped `asc iap submit` shortcut is deprecated. Use the versioned
+workflow below for new review submissions.
 
 For an API 4.4.1 IAP version, use its version ID throughout the v2 metadata,
 image, and review flow:

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -188,13 +188,66 @@ the existing submission:
 
 ```bash
 asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+```
+
+Branch on the number of returned versions before any write:
+
+- Zero: create one version and capture `.data.id` as
+  `SUBSCRIPTION_VERSION_ID`.
+- One: reuse `.data[0].id` as `SUBSCRIPTION_VERSION_ID`; do not create.
+- More than one: stop and require the user to choose an explicit version ID.
+
+Run this only in the zero-result branch:
+
+```bash
 asc subscriptions versions create --subscription-id "SUB_ID" --output json
-# Capture SUBSCRIPTION_VERSION_ID from list .data[0].id or create .data.id.
+```
+
+Resolve the intended locale before writing:
+
+```bash
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
+```
+
+If `en-US` is absent, create it:
+
+```bash
 asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium" --description "Premium access"
+```
+
+If the single resolved `en-US` localization exists but differs, update that
+resolved ID. If it already matches, reuse it and do nothing. Stop if locale
+resolution is ambiguous.
+
+```bash
 asc subscriptions versions localizations update --id "SUBSCRIPTION_LOC_ID" --name "Premium" --description "Premium access"
+```
+
+Resolve images before writing:
+
+```bash
 asc subscriptions versions images list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
+```
+
+If the intended image is already present, reuse it and do nothing. If no image
+is present, upload it:
+
+```bash
 asc subscriptions versions images upload --version-id "SUBSCRIPTION_VERSION_ID" --file "./promotional.png"
+```
+
+If a different image must be replaced, make that a separate, explicitly
+confirmed branch using its resolved ID, then upload the replacement:
+
+```bash
+asc subscriptions versions images delete --id "SUBSCRIPTION_IMAGE_ID" --confirm
+asc subscriptions versions images upload --version-id "SUBSCRIPTION_VERSION_ID" --file "./promotional.png"
+```
+
+Inspect the resolved version and children before adding the version to the
+existing review submission:
+
+```bash
 asc subscriptions versions view --id "SUBSCRIPTION_VERSION_ID" --output table
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
 asc subscriptions versions images primary --version-id "SUBSCRIPTION_VERSION_ID" --output table
@@ -206,25 +259,48 @@ Subscription group versions follow the same existing-submission model:
 
 ```bash
 asc subscriptions groups versions list --group-id "GROUP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+```
+
+Branch on the number of returned group versions before any write:
+
+- Zero: create one version and capture `.data.id` as `GROUP_VERSION_ID`.
+- One: reuse `.data[0].id` as `GROUP_VERSION_ID`; do not create.
+- More than one: stop and require the user to choose an explicit version ID.
+
+Run this only in the zero-result branch:
+
+```bash
 asc subscriptions groups versions create --group-id "GROUP_ID" --output json
-# Capture GROUP_VERSION_ID from list .data[0].id or create .data.id.
+```
+
+Resolve the intended locale before writing:
+
+```bash
 asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output json
+```
+
+If `en-US` is absent, create it:
+
+```bash
 asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Premium"
+```
+
+If the single resolved `en-US` localization exists but differs, update that
+resolved ID. If it already matches, reuse it and do nothing. Stop if locale
+resolution is ambiguous.
+
+```bash
 asc subscriptions groups versions localizations update --id "GROUP_LOC_ID" --name "Premium"
+```
+
+Inspect the resolved group version and localizations before adding it to the
+existing review submission:
+
+```bash
 asc subscriptions groups versions view --version-id "GROUP_VERSION_ID" --output table
 asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
 asc review items add --submission "SUBMISSION_ID" --item-type subscriptionGroupVersions --item-id "GROUP_VERSION_ID"
 ```
-
-For each list above, reuse its single `PREPARE_FOR_SUBMISSION` result. Create
-only when the result is empty; if multiple matches are returned, stop and
-require an explicit version ID.
-
-The child writes are conditional too: create a missing locale, update its
-resolved ID only when values differ, and no-op when it already matches. Upload
-the subscription image only when the version has no intended image; replace an
-existing asset only as a separate, explicitly confirmed delete-and-upload
-operation.
 
 ### In-app purchases need review readiness or first-version inclusion
 
@@ -246,26 +322,71 @@ image, and review flow:
 
 ```bash
 asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+```
+
+Branch on the number of returned IAP versions before any write:
+
+- Zero: create one version and capture `.data.id` as `IAP_VERSION_ID`.
+- One: reuse `.data[0].id` as `IAP_VERSION_ID`; do not create.
+- More than one: stop and require the user to choose an explicit version ID.
+
+Run this only in the zero-result branch:
+
+```bash
 asc iap versions create --iap-id "IAP_ID" --output json
-# Capture IAP_VERSION_ID from list .data[0].id or create .data.id.
+```
+
+Resolve the intended locale before writing:
+
+```bash
 asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output json
+```
+
+If `en-US` is absent, create it:
+
+```bash
 asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Premium" --description "Unlock premium features"
+```
+
+If the single resolved `en-US` localization exists but differs, update that
+resolved ID. If it already matches, reuse it and do nothing. Stop if locale
+resolution is ambiguous.
+
+```bash
 asc iap versions localizations update --localization-id "IAP_LOC_ID" --name "Premium" --description "Unlock premium features"
+```
+
+Resolve images before writing:
+
+```bash
 asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output json
+```
+
+If the intended image is already present, reuse it and do nothing. If no image
+is present, create it:
+
+```bash
 asc iap versions images create --version-id "IAP_VERSION_ID" --file "./review.png"
+```
+
+If a different image must be replaced, make that a separate, explicitly
+confirmed branch using its resolved ID, then create the replacement:
+
+```bash
+asc iap versions images delete --image-id "IAP_IMAGE_ID" --confirm
+asc iap versions images create --version-id "IAP_VERSION_ID" --file "./review.png"
+```
+
+Inspect the resolved version and children before adding it to the existing
+review submission:
+
+```bash
 asc iap versions view --version-id "IAP_VERSION_ID" --output table
 asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output table
 asc iap versions image --version-id "IAP_VERSION_ID" --output table
 asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output table
 asc iap versions submit --version-id "IAP_VERSION_ID" --submission "SUBMISSION_ID" --confirm
 ```
-
-Reuse the single `PREPARE_FOR_SUBMISSION` version. Create only when the list is
-empty, and stop for an explicit version ID if multiple matches are returned.
-Create the localization or image only when the corresponding list has no
-intended match; update a resolved localization only when values differ. Replace
-an existing image only through a separate, explicitly confirmed delete-and-
-create operation.
 
 For the first IAP on an app, or the first time adding a new IAP type, Apple may require selecting the IAP from the app version's "In-App Purchases and Subscriptions" section before submitting the app version. Prepare the IAP with localization, pricing, and review screenshot data first.
 

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -187,17 +187,25 @@ For an API 4.4.1 subscription version, prepare the version-scoped metadata and
 add that version—not the subscription product—to a review submission:
 
 ```bash
-asc subscriptions versions create --subscription-id "SUB_ID"
+asc subscriptions versions create --subscription-id "SUB_ID" --output json
+# Capture .data.id from the create response as SUBSCRIPTION_VERSION_ID.
 asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium" --description "Premium access"
-asc subscriptions versions images upload --version-id "SUBSCRIPTION_VERSION_ID" --file "./review.png"
+asc subscriptions versions images upload --version-id "SUBSCRIPTION_VERSION_ID" --file "./promotional.png"
+asc subscriptions versions view --id "SUBSCRIPTION_VERSION_ID" --output table
+asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
+asc subscriptions versions images primary --version-id "SUBSCRIPTION_VERSION_ID" --output table
+asc subscriptions versions images list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
 asc review items add --submission "SUBMISSION_ID" --item-type subscriptionVersions --item-id "SUBSCRIPTION_VERSION_ID"
 ```
 
 Subscription group versions follow the same review-item model:
 
 ```bash
-asc subscriptions groups versions create --group-id "GROUP_ID"
+asc subscriptions groups versions create --group-id "GROUP_ID" --output json
+# Capture .data.id from the create response as GROUP_VERSION_ID.
 asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Premium"
+asc subscriptions groups versions view --version-id "GROUP_VERSION_ID" --output table
+asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
 asc review items add --submission "SUBMISSION_ID" --item-type subscriptionGroupVersions --item-id "GROUP_VERSION_ID"
 ```
 
@@ -223,9 +231,14 @@ For an API 4.4.1 IAP version, use its version ID throughout the v2 metadata,
 image, and review flow:
 
 ```bash
-asc iap versions create --iap-id "IAP_ID"
+asc iap versions create --iap-id "IAP_ID" --output json
+# Capture .data.id from the create response as IAP_VERSION_ID.
 asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Premium" --description "Unlock premium features"
 asc iap versions images create --version-id "IAP_VERSION_ID" --file "./review.png"
+asc iap versions view --version-id "IAP_VERSION_ID" --output table
+asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output table
+asc iap versions image --version-id "IAP_VERSION_ID" --output table
+asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output table
 asc iap versions submit --version-id "IAP_VERSION_ID" --submission "SUBMISSION_ID" --confirm
 ```
 

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -189,8 +189,11 @@ the existing submission:
 ```bash
 asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc subscriptions versions create --subscription-id "SUB_ID" --output json
-# Capture .data.id from the create response as SUBSCRIPTION_VERSION_ID.
+# Capture SUBSCRIPTION_VERSION_ID from list .data[0].id or create .data.id.
+asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
 asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium" --description "Premium access"
+asc subscriptions versions localizations update --id "SUBSCRIPTION_LOC_ID" --name "Premium" --description "Premium access"
+asc subscriptions versions images list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
 asc subscriptions versions images upload --version-id "SUBSCRIPTION_VERSION_ID" --file "./promotional.png"
 asc subscriptions versions view --id "SUBSCRIPTION_VERSION_ID" --output table
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
@@ -204,8 +207,10 @@ Subscription group versions follow the same existing-submission model:
 ```bash
 asc subscriptions groups versions list --group-id "GROUP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc subscriptions groups versions create --group-id "GROUP_ID" --output json
-# Capture .data.id from the create response as GROUP_VERSION_ID.
+# Capture GROUP_VERSION_ID from list .data[0].id or create .data.id.
+asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output json
 asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Premium"
+asc subscriptions groups versions localizations update --id "GROUP_LOC_ID" --name "Premium"
 asc subscriptions groups versions view --version-id "GROUP_VERSION_ID" --output table
 asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
 asc review items add --submission "SUBMISSION_ID" --item-type subscriptionGroupVersions --item-id "GROUP_VERSION_ID"
@@ -214,6 +219,12 @@ asc review items add --submission "SUBMISSION_ID" --item-type subscriptionGroupV
 For each list above, reuse its single `PREPARE_FOR_SUBMISSION` result. Create
 only when the result is empty; if multiple matches are returned, stop and
 require an explicit version ID.
+
+The child writes are conditional too: create a missing locale, update its
+resolved ID only when values differ, and no-op when it already matches. Upload
+the subscription image only when the version has no intended image; replace an
+existing asset only as a separate, explicitly confirmed delete-and-upload
+operation.
 
 ### In-app purchases need review readiness or first-version inclusion
 
@@ -236,8 +247,11 @@ image, and review flow:
 ```bash
 asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc iap versions create --iap-id "IAP_ID" --output json
-# Capture .data.id from the create response as IAP_VERSION_ID.
+# Capture IAP_VERSION_ID from list .data[0].id or create .data.id.
+asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output json
 asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Premium" --description "Unlock premium features"
+asc iap versions localizations update --localization-id "IAP_LOC_ID" --name "Premium" --description "Unlock premium features"
+asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output json
 asc iap versions images create --version-id "IAP_VERSION_ID" --file "./review.png"
 asc iap versions view --version-id "IAP_VERSION_ID" --output table
 asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output table
@@ -248,6 +262,10 @@ asc iap versions submit --version-id "IAP_VERSION_ID" --submission "SUBMISSION_I
 
 Reuse the single `PREPARE_FOR_SUBMISSION` version. Create only when the list is
 empty, and stop for an explicit version ID if multiple matches are returned.
+Create the localization or image only when the corresponding list has no
+intended match; update a resolved localization only when values differ. Replace
+an existing image only through a separate, explicitly confirmed delete-and-
+create operation.
 
 For the first IAP on an app, or the first time adding a new IAP type, Apple may require selecting the IAP from the app version's "In-App Purchases and Subscriptions" section before submitting the app version. Prepare the IAP with localization, pricing, and review screenshot data first.
 

--- a/skills/asc-revenuecat-catalog-sync/SKILL.md
+++ b/skills/asc-revenuecat-catalog-sync/SKILL.md
@@ -100,13 +100,16 @@ only when the fully paginated read proves it is missing. A RevenueCat product
 mapping is not proof that the corresponding ASC subscription is review-ready.
 
 ```bash
-# Resolve GROUP_ID by exact referenceName. Create only if absent.
+# Resolve GROUP_ID by exact referenceName.
 asc subscriptions groups list --app "APP_ID" --paginate --output json
+# If and only if the fully paginated list has zero exact matches:
 asc subscriptions groups create --app "APP_ID" --reference-name "Premium" --output json
+# For one match, reuse its ID. For more than one, stop and require an explicit GROUP_ID.
 
 # Resolve SUB_ID by exact productId within GROUP_ID. Run setup only for a missing
 # parent or an explicitly approved reconciliation of that same product ID.
 asc subscriptions list --group-id "GROUP_ID" --paginate --output json
+# If and only if the fully paginated list has zero exact matches, run setup:
 asc subscriptions setup \
   --app "APP_ID" \
   --group-id "GROUP_ID" \
@@ -119,10 +122,14 @@ asc subscriptions setup \
   --territories "USA" \
   --no-verify \
   --output json
+# For one match, reuse its ID. For more than one, stop and require an explicit SUB_ID.
+# Re-run setup for an existing SUB_ID only for an explicitly approved reconciliation.
 
 # Resolve the unique mutable group version for this review lifecycle.
 asc subscriptions groups versions list --group-id "GROUP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+# If and only if the list has zero matches:
 asc subscriptions groups versions create --group-id "GROUP_ID" --output json
+# For one match, reuse .data[0].id. For more than one, stop and require an explicit GROUP_VERSION_ID.
 
 # Resolve the en-US localization on GROUP_VERSION_ID. Create it only when
 # missing; update the resolved localization ID when its values differ.
@@ -132,7 +139,9 @@ asc subscriptions groups versions localizations update --id "GROUP_LOC_ID" --nam
 
 # Resolve the unique mutable subscription version for this review lifecycle.
 asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+# If and only if the list has zero matches:
 asc subscriptions versions create --subscription-id "SUB_ID" --output json
+# For one match, reuse .data[0].id. For more than one, stop and require an explicit SUBSCRIPTION_VERSION_ID.
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
 asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium Monthly" --description "Unlock all premium features." --output json
 asc subscriptions versions localizations update --id "SUBSCRIPTION_LOC_ID" --name "Premium Monthly" --description "Unlock all premium features."
@@ -142,18 +151,22 @@ asc subscriptions groups versions localizations list --version-id "GROUP_VERSION
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
 asc validate subscriptions --app "APP_ID" --output table
 
-# Resolve IAP_ID by exact productId. Create only if absent.
+# Resolve IAP_ID by exact productId.
 asc iap list --app "APP_ID" --paginate --output json
+# If and only if the fully paginated list has zero exact matches:
 asc iap create \
   --app "APP_ID" \
   --type NON_CONSUMABLE \
   --ref-name "Lifetime" \
   --product-id "com.example.lifetime" \
   --output json
+# For one match, reuse its ID. For more than one, stop and require an explicit IAP_ID.
 
 # Resolve the unique mutable IAP version for this review lifecycle.
 asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+# If and only if the list has zero matches:
 asc iap versions create --iap-id "IAP_ID" --output json
+# For one match, reuse .data[0].id. For more than one, stop and require an explicit IAP_VERSION_ID.
 asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output json
 asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Lifetime" --description "Unlock all premium features." --output json
 asc iap versions localizations update --localization-id "IAP_LOC_ID" --name "Lifetime" --description "Unlock all premium features."

--- a/skills/asc-revenuecat-catalog-sync/SKILL.md
+++ b/skills/asc-revenuecat-catalog-sync/SKILL.md
@@ -120,9 +120,8 @@ asc subscriptions setup \
   --no-verify \
   --output json
 
-# Resolve the group version for the intended review lifecycle. Create only if
-# no suitable version exists; none of the version families has a delete command.
-asc subscriptions groups versions list --group-id "GROUP_ID" --paginate --output json
+# Resolve the unique mutable group version for this review lifecycle.
+asc subscriptions groups versions list --group-id "GROUP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc subscriptions groups versions create --group-id "GROUP_ID" --output json
 
 # Resolve the en-US localization on GROUP_VERSION_ID. Create it only when
@@ -131,9 +130,8 @@ asc subscriptions groups versions localizations list --version-id "GROUP_VERSION
 asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Premium"
 asc subscriptions groups versions localizations update --id "GROUP_LOC_ID" --name "Premium"
 
-# Resolve the subscription version for the intended review lifecycle. Create
-# only if no suitable version exists, then resolve its en-US localization.
-asc subscriptions versions list --subscription-id "SUB_ID" --paginate --output json
+# Resolve the unique mutable subscription version for this review lifecycle.
+asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc subscriptions versions create --subscription-id "SUB_ID" --output json
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
 asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium Monthly" --description "Unlock all premium features."
@@ -153,9 +151,8 @@ asc iap create \
   --product-id "com.example.lifetime" \
   --output json
 
-# Resolve the IAP version for the intended review lifecycle. Create only if no
-# suitable version exists, then create or update the resolved en-US localization.
-asc iap versions list --iap-id "IAP_ID" --paginate --output json
+# Resolve the unique mutable IAP version for this review lifecycle.
+asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc iap versions create --iap-id "IAP_ID" --output json
 asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output json
 asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Lifetime" --description "Unlock all premium features."
@@ -167,9 +164,11 @@ Each adjacent create/update pair above is conditional, not a sequence to run
 blindly: create when the list has no match, update when the resolved match has
 different values, and do nothing when it already matches. Capture `.data.id`
 from a create response or `.data[].id` from the preceding list as the canonical
-ID used by later commands. Do not create a new version merely because a rerun
-already has one; parent deletion did not reliably cascade IAP or subscription
-versions in live testing.
+ID used by later commands. For each version list, zero
+`PREPARE_FOR_SUBMISSION` matches means create, one means reuse that ID, and more
+than one means stop and require the user to choose an explicit version ID. Do
+not create a version to resolve ambiguity: parent deletion did not reliably
+cascade IAP or subscription versions in live testing.
 
 `subscriptions setup` finishes the parent, App Review screenshot delivery,
 complete App Store price matrix, and sale availability. The version-scoped

--- a/skills/asc-revenuecat-catalog-sync/SKILL.md
+++ b/skills/asc-revenuecat-catalog-sync/SKILL.md
@@ -93,15 +93,20 @@ Suggested entitlement policy:
 
 ### Step D - Ensure missing ASC items (if requested)
 
-Create or complete ASC resources first, then re-read ASC to capture canonical
-IDs. A RevenueCat product mapping is not proof that the corresponding ASC
-subscription is review-ready.
+Resolve every parent and version before writing. Match groups by exact reference
+name and products by `productId`; never treat a display name as identity. Reuse
+the canonical ID when the resource already exists, and run a create command
+only when the fully paginated read proves it is missing. A RevenueCat product
+mapping is not proof that the corresponding ASC subscription is review-ready.
 
 ```bash
-# create subscription group and capture .data.id as GROUP_ID
+# Resolve GROUP_ID by exact referenceName. Create only if absent.
+asc subscriptions groups list --app "APP_ID" --paginate --output json
 asc subscriptions groups create --app "APP_ID" --reference-name "Premium" --output json
 
-# create or converge the subscription parent, screenshot, pricing, and availability
+# Resolve SUB_ID by exact productId within GROUP_ID. Run setup only for a missing
+# parent or an explicitly approved reconciliation of that same product ID.
+asc subscriptions list --group-id "GROUP_ID" --paginate --output json
 asc subscriptions setup \
   --app "APP_ID" \
   --group-id "GROUP_ID" \
@@ -115,18 +120,32 @@ asc subscriptions setup \
   --no-verify \
   --output json
 
-# capture .subscriptionId as SUB_ID, then create version-scoped metadata
+# Resolve the group version for the intended review lifecycle. Create only if
+# no suitable version exists; none of the version families has a delete command.
+asc subscriptions groups versions list --group-id "GROUP_ID" --paginate --output json
 asc subscriptions groups versions create --group-id "GROUP_ID" --output json
-# capture .data.id as GROUP_VERSION_ID
+
+# Resolve the en-US localization on GROUP_VERSION_ID. Create it only when
+# missing; update the resolved localization ID when its values differ.
+asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output json
 asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Premium"
+asc subscriptions groups versions localizations update --id "GROUP_LOC_ID" --name "Premium"
+
+# Resolve the subscription version for the intended review lifecycle. Create
+# only if no suitable version exists, then resolve its en-US localization.
+asc subscriptions versions list --subscription-id "SUB_ID" --paginate --output json
 asc subscriptions versions create --subscription-id "SUB_ID" --output json
-# capture .data.id as SUBSCRIPTION_VERSION_ID
+asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
 asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium Monthly" --description "Unlock all premium features."
+asc subscriptions versions localizations update --id "SUBSCRIPTION_LOC_ID" --name "Premium Monthly" --description "Unlock all premium features."
+
+# Read back the exact versions selected above, then run the final validator.
 asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
 asc validate subscriptions --app "APP_ID" --output table
 
-# create iap
+# Resolve IAP_ID by exact productId. Create only if absent.
+asc iap list --app "APP_ID" --paginate --output json
 asc iap create \
   --app "APP_ID" \
   --type NON_CONSUMABLE \
@@ -134,12 +153,23 @@ asc iap create \
   --product-id "com.example.lifetime" \
   --output json
 
-# capture .data.id as IAP_ID, then create version-scoped metadata
+# Resolve the IAP version for the intended review lifecycle. Create only if no
+# suitable version exists, then create or update the resolved en-US localization.
+asc iap versions list --iap-id "IAP_ID" --paginate --output json
 asc iap versions create --iap-id "IAP_ID" --output json
-# capture .data.id as IAP_VERSION_ID
+asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output json
 asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Lifetime" --description "Unlock all premium features."
+asc iap versions localizations update --localization-id "IAP_LOC_ID" --name "Lifetime" --description "Unlock all premium features."
 asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output table
 ```
+
+Each adjacent create/update pair above is conditional, not a sequence to run
+blindly: create when the list has no match, update when the resolved match has
+different values, and do nothing when it already matches. Capture `.data.id`
+from a create response or `.data[].id` from the preceding list as the canonical
+ID used by later commands. Do not create a new version merely because a rerun
+already has one; parent deletion did not reliably cascade IAP or subscription
+versions in live testing.
 
 `subscriptions setup` finishes the parent, App Review screenshot delivery,
 complete App Store price matrix, and sale availability. The version-scoped

--- a/skills/asc-revenuecat-catalog-sync/SKILL.md
+++ b/skills/asc-revenuecat-catalog-sync/SKILL.md
@@ -146,10 +146,10 @@ asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION
 asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium Monthly" --description "Unlock all premium features." --output json
 asc subscriptions versions localizations update --id "SUBSCRIPTION_LOC_ID" --name "Premium Monthly" --description "Unlock all premium features."
 
-# Read back the exact versions selected above, then run the final validator.
+# Read back the exact versions selected above, then run the final strict validator.
 asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
-asc validate subscriptions --app "APP_ID" --output table
+asc validate subscriptions --app "APP_ID" --strict --output table
 
 # Resolve IAP_ID by exact productId.
 asc iap list --app "APP_ID" --paginate --output json
@@ -197,17 +197,20 @@ the selected base price is unchanged, re-run the same setup inputs with
 `--repair`. Repair atomically rebuilds and re-saves the complete equalized price
 matrix; it is not a duplicate single-price POST.
 
-After every ASC subscription create, update, or repair, require this final gate
-before creating or attaching the RevenueCat subscription product:
+For every resolved ASC subscription, require this final gate before creating or
+attaching its RevenueCat product. Run it after the final ASC reconciliation even
+when the subscription and its selected version were reused without any ASC
+write:
 
 ```bash
 mkdir -p "./audit"
-asc validate subscriptions --app "APP_ID" --output json --pretty \
+asc validate subscriptions --app "APP_ID" --strict --output json --pretty \
   > "./audit/subscriptions-validation.json"
 ```
 
-After every ASC IAP create or update, require the IAP gate in strict mode so
-warnings also block the RevenueCat product mapping:
+For every resolved ASC IAP, require the IAP gate before creating or attaching
+its RevenueCat product. Run it after the final ASC reconciliation even when the
+IAP and its selected version were reused without any ASC write:
 
 ```bash
 mkdir -p "./audit"
@@ -215,11 +218,14 @@ asc validate iap --app "APP_ID" --strict --output json --pretty \
   > "./audit/iap-validation.json"
 ```
 
-Do not treat setup as successful if Apple still reports `MISSING_METADATA`, the
-review screenshot is not `COMPLETE`, or the validator reports incomplete or
-unverified pricing coverage. Do not attach an IAP while its strict validator
-reports warnings or errors. Direct redirection preserves each validator's exit
-status. Retain `./audit/subscriptions-validation.json` and
+Both commands are strict mapping gates, not post-write smoke tests. Do not map
+any resolved or reused subscription while validation reports warnings, errors,
+`MISSING_METADATA`, a review screenshot that is not `COMPLETE`, or incomplete
+or unverified pricing coverage. Do not map any resolved or reused IAP while its
+validator reports warnings or errors. A zero-write audit or apply run must still
+execute the applicable gate and require a zero exit status before RevenueCat
+product creation or attachment. Direct redirection preserves each validator's
+exit status. Retain `./audit/subscriptions-validation.json` and
 `./audit/iap-validation.json` as final audit evidence.
 
 ### Step E - Ensure RevenueCat app and products
@@ -287,8 +293,8 @@ Failures:
 - Use full pagination (`--paginate` for ASC, `starting_after` for RevenueCat tools).
 - Continue processing after per-item failures and report all failures together.
 - Never auto-delete ASC or RevenueCat resources in this skill.
-- After ASC subscription writes, run `asc validate subscriptions --app "APP_ID" --output json --pretty`, save its JSON, and block RevenueCat attachment for subscriptions with unresolved ASC blockers.
-- After ASC IAP writes, run `asc validate iap --app "APP_ID" --strict --output json --pretty`, save its JSON, and block RevenueCat attachment if it exits non-zero.
+- For every resolved subscription, including a reused no-write match, run `asc validate subscriptions --app "APP_ID" --strict --output json --pretty`, save its JSON, and block RevenueCat creation or attachment unless the gate exits zero with no missing metadata or incomplete pricing.
+- For every resolved IAP, including a reused no-write match, run `asc validate iap --app "APP_ID" --strict --output json --pretty`, save its JSON, and block RevenueCat creation or attachment unless the gate exits zero.
 
 ## Common pitfalls
 - Wrong RevenueCat `project_id` or app ID.

--- a/skills/asc-revenuecat-catalog-sync/SKILL.md
+++ b/skills/asc-revenuecat-catalog-sync/SKILL.md
@@ -98,39 +98,57 @@ IDs. A RevenueCat product mapping is not proof that the corresponding ASC
 subscription is review-ready.
 
 ```bash
-# create subscription group
-asc subscriptions groups create --app "APP_ID" --reference-name "Premium"
+# create subscription group and capture .data.id as GROUP_ID
+asc subscriptions groups create --app "APP_ID" --reference-name "Premium" --output json
 
-# create or converge a review-ready subscription in one workflow
+# create or converge the subscription parent, screenshot, pricing, and availability
 asc subscriptions setup \
   --app "APP_ID" \
-  --group-reference-name "Premium" \
-  --group-locale "en-US" \
-  --group-display-name "Premium" \
+  --group-id "GROUP_ID" \
   --reference-name "Monthly" \
   --product-id "com.example.premium.monthly" \
   --subscription-period ONE_MONTH \
-  --locale "en-US" \
-  --display-name "Premium Monthly" \
-  --description "Unlock all premium features." \
   --review-screenshot "./review.png" \
   --price "3.99" \
   --price-territory "USA" \
-  --territories "USA"
+  --territories "USA" \
+  --no-verify \
+  --output json
+
+# capture .subscriptionId as SUB_ID, then create version-scoped metadata
+asc subscriptions groups versions create --group-id "GROUP_ID" --output json
+# capture .data.id as GROUP_VERSION_ID
+asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Premium"
+asc subscriptions versions create --subscription-id "SUB_ID" --output json
+# capture .data.id as SUBSCRIPTION_VERSION_ID
+asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium Monthly" --description "Unlock all premium features."
+asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
+asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
+asc validate subscriptions --app "APP_ID" --output table
 
 # create iap
 asc iap create \
   --app "APP_ID" \
   --type NON_CONSUMABLE \
   --ref-name "Lifetime" \
-  --product-id "com.example.lifetime"
+  --product-id "com.example.lifetime" \
+  --output json
+
+# capture .data.id as IAP_ID, then create version-scoped metadata
+asc iap versions create --iap-id "IAP_ID" --output json
+# capture .data.id as IAP_VERSION_ID
+asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Lifetime" --description "Unlock all premium features."
+asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output table
 ```
 
-`subscriptions setup` must finish the ASC metadata that RevenueCat cannot:
-group localization, subscription localization, App Review screenshot delivery,
-the complete App Store price matrix, and sale availability. Keep sale
-availability scoped to the requested territories; pricing still needs Apple's
-complete equalized territory matrix.
+`subscriptions setup` finishes the parent, App Review screenshot delivery,
+complete App Store price matrix, and sale availability. The version-scoped
+commands finish the group and subscription localizations that RevenueCat
+cannot. Keep sale availability scoped to the requested territories; pricing
+still needs Apple's complete equalized territory matrix. `--no-verify` is
+intentional in this split workflow because final verification must wait until
+the version metadata exists; the explicit readbacks and validator are the final
+gate.
 
 If an existing API-created subscription remains `MISSING_METADATA` even though
 the selected base price is unchanged, re-run the same setup inputs with

--- a/skills/asc-revenuecat-catalog-sync/SKILL.md
+++ b/skills/asc-revenuecat-catalog-sync/SKILL.md
@@ -127,14 +127,14 @@ asc subscriptions groups versions create --group-id "GROUP_ID" --output json
 # Resolve the en-US localization on GROUP_VERSION_ID. Create it only when
 # missing; update the resolved localization ID when its values differ.
 asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output json
-asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Premium"
+asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Premium" --output json
 asc subscriptions groups versions localizations update --id "GROUP_LOC_ID" --name "Premium"
 
 # Resolve the unique mutable subscription version for this review lifecycle.
 asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc subscriptions versions create --subscription-id "SUB_ID" --output json
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
-asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium Monthly" --description "Unlock all premium features."
+asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium Monthly" --description "Unlock all premium features." --output json
 asc subscriptions versions localizations update --id "SUBSCRIPTION_LOC_ID" --name "Premium Monthly" --description "Unlock all premium features."
 
 # Read back the exact versions selected above, then run the final validator.
@@ -155,7 +155,7 @@ asc iap create \
 asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 asc iap versions create --iap-id "IAP_ID" --output json
 asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output json
-asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Lifetime" --description "Unlock all premium features."
+asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Lifetime" --description "Unlock all premium features." --output json
 asc iap versions localizations update --localization-id "IAP_LOC_ID" --name "Lifetime" --description "Unlock all premium features."
 asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output table
 ```

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -92,6 +92,11 @@ when they accurately describe the app:
 asc age-rating edit --app "APP_ID" --social-media false --social-media-age-restricted false
 ```
 
+Apple requires `userGeneratedContent=true` before `socialMedia` can be true.
+It also requires both `ageAssurance=true` and `socialMedia=true` before
+`socialMediaAgeRestricted` can be true. Inspect the current declaration before
+a partial edit, or set every prerequisite explicitly in the same command.
+
 Prefer `--age-rating-override-v2` when an override is required; the original
 `--age-rating-override` flag is deprecated.
 

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -76,7 +76,26 @@ asc apps content-rights view --app "APP_ID"
 asc apps content-rights edit --app "APP_ID" --uses-third-party-content=false
 ```
 
-### 5. Version metadata and localizations
+### 5. Age rating declaration
+
+Inspect the current declaration before editing it:
+
+```bash
+asc age-rating view --app "APP_ID" --output table
+```
+
+API 4.4.1 adds declarations for advertising, age assurance, health or wellness,
+messaging and chat, parental controls, social media, and age-restricted social
+media. Set only values that accurately describe the app:
+
+```bash
+asc age-rating edit --app "APP_ID" --advertising false --age-assurance false --health-or-wellness-topics false --messaging-and-chat false --parental-controls false --social-media false --social-media-age-restricted false
+```
+
+Prefer `--age-rating-override-v2` when an override is required; the original
+`--age-rating-override` flag is deprecated.
+
+### 6. Version metadata and localizations
 
 ```bash
 asc versions view --version-id "VERSION_ID" --include-build --include-submission
@@ -92,7 +111,7 @@ asc metadata push --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metad
 asc metadata push --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
 ```
 
-### 6. App info localizations and privacy policy
+### 7. App info localizations and privacy policy
 
 ```bash
 asc apps info list --app "APP_ID" --output table
@@ -105,7 +124,7 @@ For subscription or IAP apps, make sure privacy policy URL is populated:
 asc app-setup info set --app "APP_ID" --primary-locale "en-US" --privacy-policy-url "https://example.com/privacy"
 ```
 
-### 7. Screenshots
+### 8. Screenshots
 
 ```bash
 asc screenshots list --version-localization "LOC_ID" --output table
@@ -113,7 +132,7 @@ asc screenshots sizes --output table
 asc screenshots validate --path "./screenshots" --device-type "IPHONE_65" --output table
 ```
 
-### 8. Digital goods readiness
+### 9. Digital goods readiness
 
 ```bash
 asc validate iap --app "APP_ID" --output table
@@ -126,7 +145,16 @@ Use JSON when you need exact diagnostics:
 asc validate subscriptions --app "APP_ID" --output json --pretty
 ```
 
-### 9. App Privacy advisory
+When the product uses API 4.4.1 version-scoped metadata, inspect the exact
+version resources that will be submitted:
+
+```bash
+asc iap versions list --iap-id "IAP_ID" --paginate --output table
+asc subscriptions versions list --subscription-id "SUB_ID" --paginate --output table
+asc subscriptions groups versions list --group-id "GROUP_ID" --paginate --output table
+```
+
+### 10. App Privacy advisory
 
 The public API cannot fully verify App Privacy publish state. If validation reports an advisory, use the web-session flow or confirm manually.
 
@@ -173,6 +201,9 @@ Use the lower-level review-submission API when the submission needs multiple rev
 asc review submissions-create --app "APP_ID" --platform IOS
 asc review items add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
 asc review items add --submission "SUBMISSION_ID" --item-type gameCenterChallengeVersions --item-id "GC_CHALLENGE_VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type inAppPurchaseVersions --item-id "IAP_VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type subscriptionVersions --item-id "SUBSCRIPTION_VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type subscriptionGroupVersions --item-id "GROUP_VERSION_ID"
 asc review submissions-submit --id "SUBMISSION_ID" --confirm
 ```
 

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -84,12 +84,12 @@ Inspect the current declaration before editing it:
 asc age-rating view --app "APP_ID" --output table
 ```
 
-API 4.4.1 adds declarations for advertising, age assurance, health or wellness,
-messaging and chat, parental controls, social media, and age-restricted social
-media. Set only values that accurately describe the app:
+API 4.4.1 adds the `socialMedia` and `socialMediaAgeRestricted` declarations;
+the other age-rating declarations predate this schema. Set the new values only
+when they accurately describe the app:
 
 ```bash
-asc age-rating edit --app "APP_ID" --advertising false --age-assurance false --health-or-wellness-topics false --messaging-and-chat false --parental-controls false --social-media false --social-media-age-restricted false
+asc age-rating edit --app "APP_ID" --social-media false --social-media-age-restricted false
 ```
 
 Prefer `--age-rating-override-v2` when an override is required; the original
@@ -150,9 +150,22 @@ version resources that will be submitted:
 
 ```bash
 asc iap versions list --iap-id "IAP_ID" --paginate --output table
+asc iap versions view --version-id "IAP_VERSION_ID" --output table
+asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output table
+asc iap versions image --version-id "IAP_VERSION_ID" --output table
+asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output table
 asc subscriptions versions list --subscription-id "SUB_ID" --paginate --output table
+asc subscriptions versions view --id "SUBSCRIPTION_VERSION_ID" --output table
+asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
+asc subscriptions versions images primary --version-id "SUBSCRIPTION_VERSION_ID" --output table
+asc subscriptions versions images list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
 asc subscriptions groups versions list --group-id "GROUP_ID" --paginate --output table
+asc subscriptions groups versions view --version-id "GROUP_VERSION_ID" --output table
+asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
 ```
+
+Capture each version `.data.id` from its create response before resolving or
+mutating these children.
 
 ### 10. App Privacy advisory
 

--- a/skills/asc-subscription-localization/SKILL.md
+++ b/skills/asc-subscription-localization/SKILL.md
@@ -83,12 +83,20 @@ description must contain at least one character.
 ```bash
 asc subscriptions groups versions localizations list --version-id "VERSION_ID" --paginate --output table
 asc subscriptions groups versions localizations create --version-id "VERSION_ID" --locale "LOCALE" --name "Group Display Name" --custom-app-name "My App"
-asc subscriptions groups versions localizations update --id "LOC_ID" --clear-custom-app-name
+asc subscriptions groups versions localizations update --id "LOC_ID" --name "Updated Group Display Name" --custom-app-name "My App"
 asc subscriptions groups versions localizations list --version-id "VERSION_ID" --paginate --output table
 ```
 
-Use `--clear-name` or `--clear-custom-app-name` only when JSON `null` is
-intended; omission leaves the attribute unchanged.
+Clearing metadata is a separate, explicit opt-in operation. After confirming
+that the user wants to remove an existing custom app name, run:
+
+```bash
+asc subscriptions groups versions localizations update --id "LOC_ID" --clear-custom-app-name
+```
+
+Do not include `--clear-name` or `--clear-custom-app-name` in the standard bulk
+localization workflow. Use either flag only when JSON `null` is deliberately
+intended; omitting the flag leaves that attribute unchanged.
 
 ## Workflow: Bulk-localize an IAP version (v2)
 

--- a/skills/asc-subscription-localization/SKILL.md
+++ b/skills/asc-subscription-localization/SKILL.md
@@ -26,9 +26,9 @@ groups. A version ID is different from its product, subscription, or group ID.
 Resolve or create versions before localizing them:
 
 ```bash
-asc iap versions list --iap-id "IAP_ID" --paginate --output table
-asc subscriptions versions list --subscription-id "SUB_ID" --paginate --output table
-asc subscriptions groups versions list --group-id "GROUP_ID" --paginate --output table
+asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output table
+asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_SUBMISSION --paginate --output table
+asc subscriptions groups versions list --group-id "GROUP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output table
 ```
 
 Create a version only when the requested review lifecycle needs a new one:
@@ -40,9 +40,10 @@ asc subscriptions groups versions create --group-id "GROUP_ID" --output json
 ```
 
 None of the three version families has a version delete command. List and
-reuse an existing version when it matches the intended review lifecycle. Live
-parent deletion did not cascade IAP or subscription versions, so do not assume
-parent deletion cleans up versions created for testing.
+reuse the single `PREPARE_FOR_SUBMISSION` version; create only for zero matches,
+and stop for an explicit ID when multiple matches exist. Live parent deletion
+did not cascade IAP or subscription versions, so do not assume parent deletion
+cleans up versions created for testing.
 
 ## Supported App Store Locales
 

--- a/skills/asc-subscription-localization/SKILL.md
+++ b/skills/asc-subscription-localization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asc-subscription-localization
-description: Bulk-localize subscription and in-app purchase display names across all App Store locales using asc. Use when you want to fill in subscription/IAP names for every language without clicking through App Store Connect manually.
+description: Bulk-localize subscription, subscription-group, and in-app purchase display names across App Store locales using asc, including API 4.4.1 version-scoped v2 resources. Use when filling or updating subscription/IAP names and descriptions without App Store Connect UI work.
 ---
 
 # asc subscription localization
@@ -11,6 +11,34 @@ Use this skill to bulk-create or bulk-update display names (and descriptions) fo
 - Auth configured (`asc auth login` or `ASC_*` env vars).
 - Know your app ID (`ASC_APP_ID` or `--app`).
 - Subscription groups and subscriptions already exist.
+
+## Choose the API scope first
+
+API 4.4.1 adds discrete versions for IAPs, subscriptions, and subscription
+groups. A version ID is different from its product, subscription, or group ID.
+
+- Use `asc ... versions localizations ...` when the localization belongs to a
+  version and must participate in that version's review lifecycle.
+- Use the existing `asc subscriptions localizations`,
+  `asc subscriptions groups localizations`, and `asc iap localizations`
+  commands only for the stable v1 product- or group-scoped resources.
+- Never pass a product, subscription, or group ID to a version-scoped command.
+
+Resolve or create versions before localizing them:
+
+```bash
+asc iap versions list --iap-id "IAP_ID" --paginate --output table
+asc subscriptions versions list --subscription-id "SUB_ID" --paginate --output table
+asc subscriptions groups versions list --group-id "GROUP_ID" --paginate --output table
+```
+
+Create a version only when the requested review lifecycle needs a new one:
+
+```bash
+asc iap versions create --iap-id "IAP_ID"
+asc subscriptions versions create --subscription-id "SUB_ID"
+asc subscriptions groups versions create --group-id "GROUP_ID"
+```
 
 ## Supported App Store Locales
 
@@ -23,7 +51,49 @@ ja, ko, ms, nl-NL, no, pl, pt-BR, pt-PT, ro, ru, sk,
 sv, th, tr, uk, vi, zh-Hans, zh-Hant
 ```
 
-## Workflow: Bulk-Localize a Subscription
+## Workflow: Bulk-localize a subscription version (v2)
+
+List existing localizations, create only missing locales, then verify:
+
+```bash
+asc subscriptions versions localizations list --version-id "VERSION_ID" --paginate --output table
+asc subscriptions versions localizations create --version-id "VERSION_ID" --locale "LOCALE" --name "Display Name" --description "Description"
+asc subscriptions versions localizations list --version-id "VERSION_ID" --paginate --output table
+```
+
+Updates distinguish omitted values, strings (including an empty string), and
+JSON `null`:
+
+```bash
+asc subscriptions versions localizations update --id "LOC_ID" --name "New Name" --description ""
+asc subscriptions versions localizations update --id "LOC_ID" --clear-description
+```
+
+Do not combine a value flag with its matching `--clear-name` or
+`--clear-description` flag.
+
+## Workflow: Bulk-localize a subscription group version (v2)
+
+```bash
+asc subscriptions groups versions localizations list --version-id "VERSION_ID" --paginate --output table
+asc subscriptions groups versions localizations create --version-id "VERSION_ID" --locale "LOCALE" --name "Group Display Name" --custom-app-name "My App"
+asc subscriptions groups versions localizations update --id "LOC_ID" --clear-custom-app-name
+asc subscriptions groups versions localizations list --version-id "VERSION_ID" --paginate --output table
+```
+
+Use `--clear-name` or `--clear-custom-app-name` only when JSON `null` is
+intended; omission leaves the attribute unchanged.
+
+## Workflow: Bulk-localize an IAP version (v2)
+
+```bash
+asc iap versions localizations list --version-id "VERSION_ID" --paginate --output table
+asc iap versions localizations create --version-id "VERSION_ID" --locale "LOCALE" --name "Display Name" --description "Description"
+asc iap versions localizations update --localization-id "LOC_ID" --clear-description
+asc iap versions localizations list --version-id "VERSION_ID" --paginate --output table
+```
+
+## Legacy v1 workflow: Bulk-Localize a Subscription
 
 ### 1. Resolve IDs
 
@@ -104,7 +174,7 @@ asc subscriptions localizations create --subscription-id "SUB_ID" --locale "zh-H
 asc subscriptions localizations list --subscription-id "SUB_ID" --paginate --output table
 ```
 
-## Workflow: Bulk-Localize a Subscription Group
+## Legacy v1 workflow: Bulk-Localize a Subscription Group
 
 Subscription groups also have their own display name per locale (this is the "group name" shown to users in the subscription management sheet).
 
@@ -139,7 +209,7 @@ asc subscriptions groups localizations create \
 asc subscriptions groups localizations list --group-id "GROUP_ID" --paginate --output table
 ```
 
-## Workflow: Bulk-Localize an In-App Purchase
+## Legacy v1 workflow: Bulk-Localize an In-App Purchase
 
 IAPs have their own localization commands with the same pattern.
 
@@ -221,6 +291,9 @@ asc subscriptions list --group-id "GROUP_ID" --paginate
 
 ## Agent Behavior
 
+- Resolve whether the target is version-scoped v2 or legacy v1 before listing
+  or mutating localizations.
+- Keep version IDs separate from product, subscription, and group IDs.
 - Always list existing localizations first to avoid duplicate creation errors.
 - Skip locales that already have a localization; only create missing ones.
 - When the user provides a single display name, use it for all locales (same name everywhere).

--- a/skills/asc-subscription-localization/SKILL.md
+++ b/skills/asc-subscription-localization/SKILL.md
@@ -108,42 +108,50 @@ schema permits JSON `null`.
 For a full app with multiple subscription groups and subscriptions:
 
 ```bash
-# 1. List groups and resolve each group's current version.
+# 1. List groups and resolve each group's unique mutable version.
 asc subscriptions groups list --app "APP_ID" --paginate --output json
-asc subscriptions groups versions list --group-id "GROUP_ID" --paginate --output json
+asc subscriptions groups versions list --group-id "GROUP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 
 # 2. Localize each group version.
 asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output json
 asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "LOCALE" --name "Group Display Name"
 
-# 3. List subscriptions and resolve each subscription's current version.
+# 3. List subscriptions and resolve each subscription's unique mutable version.
 asc subscriptions list --group-id "GROUP_ID" --paginate --output json
-asc subscriptions versions list --subscription-id "SUB_ID" --paginate --output json
+asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
 
 # 4. Localize each subscription version.
 asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
 asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "LOCALE" --name "Display Name" --description "Description"
 ```
 
+Apply the same zero/one/many rule to each version list: create a version for
+zero matches, reuse the one match, and stop for an explicit ID when multiple
+matches are returned.
+
 ## Agent Behavior
 
 - Use only version-scoped v2 resources for new localization work.
 - Keep version IDs separate from product, subscription, and group IDs.
 - Always list existing localizations first to avoid duplicate creation errors.
-- Skip locales that already have a localization; only create missing ones.
+- Create a missing locale, update the resolved localization ID when existing
+  values differ, and do nothing when the existing values already match.
 - When the user provides a single display name, use it for all locales (same name everywhere).
 - When the user provides translated names per locale, use the locale-specific name for each.
 - If a description is provided, pass `--description` on create. Otherwise omit it.
 - Use `--output table` for verification steps so the user can visually confirm.
 - Use explicit `--output json` for intermediate automation steps; output
   defaults are TTY-aware.
-- After bulk creation, always run the list command to verify completeness.
+- After bulk writes, always run the list command to verify completeness.
 - For apps with many subscriptions, process them sequentially per group to keep output readable.
-- If a create call fails for a locale, log the locale and error, then continue with the remaining locales. After the batch completes, report all failures together so the user can address them.
+- If a create or update call fails for a locale, log the locale and error, then
+  continue with the remaining locales. After the batch completes, report all
+  failures together so the user can address them.
 
 ## Notes
 - Subscription display names are what users see on the subscription management sheet and in purchase dialogs.
-- Creating a localization for a locale that already exists will fail; always check first.
+- Creating a localization for a locale that already exists will fail; list
+  first and update the resolved ID when a change is needed.
 - There is no bulk API; each locale requires a separate create call.
 - Use `--paginate` on list commands to ensure all existing localizations are returned.
 - Use the `asc-id-resolver` skill if you only have app names instead of IDs.

--- a/skills/asc-subscription-localization/SKILL.md
+++ b/skills/asc-subscription-localization/SKILL.md
@@ -17,11 +17,10 @@ Use this skill to bulk-create or bulk-update display names (and descriptions) fo
 API 4.4.1 adds discrete versions for IAPs, subscriptions, and subscription
 groups. A version ID is different from its product, subscription, or group ID.
 
-- Use `asc ... versions localizations ...` when the localization belongs to a
-  version and must participate in that version's review lifecycle.
-- Use the existing `asc subscriptions localizations`,
-  `asc subscriptions groups localizations`, and `asc iap localizations`
-  commands only for the stable v1 product- or group-scoped resources.
+- Use `asc ... versions localizations ...` for all new localization work.
+- Do not use the product- or group-scoped v1 localization commands. API 4.4.1
+  deprecates those resources, and the CLI now emits migration warnings for
+  their compatibility commands.
 - Never pass a product, subscription, or group ID to a version-scoped command.
 
 Resolve or create versions before localizing them:
@@ -35,10 +34,15 @@ asc subscriptions groups versions list --group-id "GROUP_ID" --paginate --output
 Create a version only when the requested review lifecycle needs a new one:
 
 ```bash
-asc iap versions create --iap-id "IAP_ID"
-asc subscriptions versions create --subscription-id "SUB_ID"
-asc subscriptions groups versions create --group-id "GROUP_ID"
+asc iap versions create --iap-id "IAP_ID" --output json
+asc subscriptions versions create --subscription-id "SUB_ID" --output json
+asc subscriptions groups versions create --group-id "GROUP_ID" --output json
 ```
+
+None of the three version families has a version delete command. List and
+reuse an existing version when it matches the intended review lifecycle. Live
+parent deletion did not cascade IAP or subscription versions, so do not assume
+parent deletion cleans up versions created for testing.
 
 ## Supported App Store Locales
 
@@ -61,16 +65,17 @@ asc subscriptions versions localizations create --version-id "VERSION_ID" --loca
 asc subscriptions versions localizations list --version-id "VERSION_ID" --paginate --output table
 ```
 
-Updates distinguish omitted values, strings (including an empty string), and
-JSON `null`:
+Updates distinguish omitted values, non-empty strings, and JSON `null`:
 
 ```bash
-asc subscriptions versions localizations update --id "LOC_ID" --name "New Name" --description ""
-asc subscriptions versions localizations update --id "LOC_ID" --clear-description
+asc subscriptions versions localizations update --id "LOC_ID" --name "New Name" --description "Updated description"
 ```
 
 Do not combine a value flag with its matching `--clear-name` or
-`--clear-description` flag.
+`--clear-description` flag. The 4.4.1 schema permits JSON `null`, but Apple's
+live service currently rejects both an empty `--description` and
+`--clear-description` for subscription-version localizations because the
+description must contain at least one character.
 
 ## Workflow: Bulk-localize a subscription group version (v2)
 
@@ -89,210 +94,39 @@ intended; omission leaves the attribute unchanged.
 ```bash
 asc iap versions localizations list --version-id "VERSION_ID" --paginate --output table
 asc iap versions localizations create --version-id "VERSION_ID" --locale "LOCALE" --name "Display Name" --description "Description"
-asc iap versions localizations update --localization-id "LOC_ID" --clear-description
+asc iap versions localizations update --localization-id "LOC_ID" --description "Updated description"
 asc iap versions localizations list --version-id "VERSION_ID" --paginate --output table
 ```
 
-## Legacy v1 workflow: Bulk-Localize a Subscription
+Apple's live service also rejects empty descriptions and
+`--clear-description` for IAP-version localizations even though the 4.4.1
+schema permits JSON `null`.
 
-### 1. Resolve IDs
-
-```bash
-# Find subscription groups
-asc subscriptions groups list --app "APP_ID" --paginate --output table
-
-# Find subscriptions within a group
-asc subscriptions list --group-id "GROUP_ID" --paginate --output table
-```
-
-### 2. Check existing localizations
-
-```bash
-asc subscriptions localizations list --subscription-id "SUB_ID" --paginate --output table
-```
-
-This shows which locales already have a name set. Only create localizations for missing locales.
-
-### 3. Create localizations for all missing locales
-
-For each locale that does not already have a localization, run:
-
-```bash
-asc subscriptions localizations create \
-  --subscription-id "SUB_ID" \
-  --locale "LOCALE" \
-  --name "Display Name"
-```
-
-For example, to set "Monthly Pro" across all locales:
-
-```bash
-# One command per locale (skip any that already exist)
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "ar-SA" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "ca" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "cs" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "da" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "de-DE" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "el" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "en-AU" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "en-CA" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "en-GB" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "es-ES" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "es-MX" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "fi" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "fr-CA" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "fr-FR" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "he" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "hi" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "hr" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "hu" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "id" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "it" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "ja" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "ko" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "ms" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "nl-NL" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "no" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "pl" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "pt-BR" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "pt-PT" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "ro" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "ru" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "sk" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "sv" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "th" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "tr" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "uk" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "vi" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "zh-Hans" --name "Monthly Pro"
-asc subscriptions localizations create --subscription-id "SUB_ID" --locale "zh-Hant" --name "Monthly Pro"
-```
-
-### 4. Verify
-
-```bash
-asc subscriptions localizations list --subscription-id "SUB_ID" --paginate --output table
-```
-
-## Legacy v1 workflow: Bulk-Localize a Subscription Group
-
-Subscription groups also have their own display name per locale (this is the "group name" shown to users in the subscription management sheet).
-
-### 1. Check existing group localizations
-
-```bash
-asc subscriptions groups localizations list --group-id "GROUP_ID" --paginate --output table
-```
-
-### 2. Create for missing locales
-
-```bash
-asc subscriptions groups localizations create \
-  --group-id "GROUP_ID" \
-  --locale "LOCALE" \
-  --name "Group Display Name"
-```
-
-Optional: set a custom app name for the group:
-
-```bash
-asc subscriptions groups localizations create \
-  --group-id "GROUP_ID" \
-  --locale "LOCALE" \
-  --name "Group Display Name" \
-  --custom-app-name "My App"
-```
-
-### 3. Verify
-
-```bash
-asc subscriptions groups localizations list --group-id "GROUP_ID" --paginate --output table
-```
-
-## Legacy v1 workflow: Bulk-Localize an In-App Purchase
-
-IAPs have their own localization commands with the same pattern.
-
-### 1. Resolve IAP ID
-
-```bash
-asc iap list --app "APP_ID" --output table
-```
-
-### 2. Check existing localizations
-
-```bash
-asc iap localizations list --iap-id "IAP_ID" --paginate --output table
-```
-
-### 3. Create for missing locales
-
-```bash
-asc iap localizations create \
-  --iap-id "IAP_ID" \
-  --locale "LOCALE" \
-  --name "Display Name"
-```
-
-Optional description:
-
-```bash
-asc iap localizations create \
-  --iap-id "IAP_ID" \
-  --locale "LOCALE" \
-  --name "Unlock All Features" \
-  --description "One-time purchase to unlock all premium features"
-```
-
-### 4. Verify
-
-```bash
-asc iap localizations list --iap-id "IAP_ID" --paginate --output table
-```
-
-## Updating Existing Localizations
-
-To change the display name for existing localizations:
-
-### Subscriptions
-```bash
-asc subscriptions localizations update --id "LOC_ID" --name "New Name"
-```
-
-### Subscription Groups
-```bash
-asc subscriptions groups localizations update --id "LOC_ID" --name "New Group Name"
-```
-
-### In-App Purchases
-```bash
-asc iap localizations update --localization-id "LOC_ID" --name "New Name"
-```
-
-To bulk-update, list existing localizations first, extract the IDs, then update each one.
-
-## Bulk-Localize All Subscriptions in an App
+## Bulk-localize all subscription versions in an app
 
 For a full app with multiple subscription groups and subscriptions:
 
 ```bash
-# 1. List all groups
-asc subscriptions groups list --app "APP_ID" --paginate
+# 1. List groups and resolve each group's current version.
+asc subscriptions groups list --app "APP_ID" --paginate --output json
+asc subscriptions groups versions list --group-id "GROUP_ID" --paginate --output json
 
-# 2. For each group, localize the group itself
-#    (repeat group localization workflow above)
+# 2. Localize each group version.
+asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output json
+asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "LOCALE" --name "Group Display Name"
 
-# 3. For each group, list subscriptions
-asc subscriptions list --group-id "GROUP_ID" --paginate
+# 3. List subscriptions and resolve each subscription's current version.
+asc subscriptions list --group-id "GROUP_ID" --paginate --output json
+asc subscriptions versions list --subscription-id "SUB_ID" --paginate --output json
 
-# 4. For each subscription, localize it
-#    (repeat subscription localization workflow above)
+# 4. Localize each subscription version.
+asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
+asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "LOCALE" --name "Display Name" --description "Description"
 ```
 
 ## Agent Behavior
 
-- Resolve whether the target is version-scoped v2 or legacy v1 before listing
-  or mutating localizations.
+- Use only version-scoped v2 resources for new localization work.
 - Keep version IDs separate from product, subscription, and group IDs.
 - Always list existing localizations first to avoid duplicate creation errors.
 - Skip locales that already have a localization; only create missing ones.

--- a/skills/asc-subscription-localization/SKILL.md
+++ b/skills/asc-subscription-localization/SKILL.md
@@ -5,7 +5,11 @@ description: Bulk-localize subscription, subscription-group, and in-app purchase
 
 # asc subscription localization
 
-Use this skill to bulk-create or bulk-update display names (and descriptions) for subscriptions, subscription groups, and in-app purchases across all App Store Connect locales. This eliminates the tedious manual process of clicking through each language in App Store Connect to set the same display name.
+Use this skill to bulk-create or bulk-update display names and, where supported,
+descriptions for subscriptions, subscription groups, and in-app purchases across
+all App Store Connect locales. This eliminates the tedious manual process of
+clicking through each language in App Store Connect to set the same display
+name.
 
 ## Preconditions
 - Auth configured (`asc auth login` or `ASC_*` env vars).
@@ -78,6 +82,11 @@ live service currently rejects both an empty `--description` and
 `--clear-description` for subscription-version localizations because the
 description must contain at least one character.
 
+Creating a missing subscription-version localization therefore requires a
+non-empty description. A display-name-only run may update the name of an
+existing localization, but must not create a missing locale until the user
+provides a non-empty locale-specific or shared fallback description.
+
 ## Workflow: Bulk-localize a subscription group version (v2)
 
 ```bash
@@ -109,7 +118,9 @@ asc iap versions localizations list --version-id "VERSION_ID" --paginate --outpu
 
 Apple's live service also rejects empty descriptions and
 `--clear-description` for IAP-version localizations even though the 4.4.1
-schema permits JSON `null`.
+schema permits JSON `null`. As with subscriptions, a display-name-only run may
+update existing IAP localizations but must not create missing locales until a
+non-empty description is available.
 
 ## Bulk-localize all subscription versions in an app
 
@@ -146,7 +157,17 @@ matches are returned.
   values differ, and do nothing when the existing values already match.
 - When the user provides a single display name, use it for all locales (same name everywhere).
 - When the user provides translated names per locale, use the locale-specific name for each.
-- If a description is provided, pass `--description` on create. Otherwise omit it.
+- For subscription- and IAP-version localizations, require a non-empty
+  `--description` on every create. If the user supplies only display names,
+  update existing localizations by resolved ID, skip creates for missing
+  locales, and ask for locale-specific descriptions or one non-empty fallback
+  description before creating them.
+- On updates to existing subscription- or IAP-version localizations, omit
+  `--description` unless the user supplied a new non-empty value; never infer an
+  empty value or clear it.
+- Subscription-group-version localizations do not have a description field.
+  Create or update their names normally, with `--custom-app-name` only when the
+  user supplied that value.
 - Use `--output table` for verification steps so the user can visually confirm.
 - Use explicit `--output json` for intermediate automation steps; output
   defaults are TTY-aware.

--- a/skills/asc-subscription-localization/SKILL.md
+++ b/skills/asc-subscription-localization/SKILL.md
@@ -99,10 +99,10 @@ asc iap versions localizations list --version-id "VERSION_ID" --paginate --outpu
 
 ```bash
 # Find subscription groups
-asc subscriptions groups list --app "APP_ID" --output table
+asc subscriptions groups list --app "APP_ID" --paginate --output table
 
 # Find subscriptions within a group
-asc subscriptions list --group-id "GROUP_ID" --output table
+asc subscriptions list --group-id "GROUP_ID" --paginate --output table
 ```
 
 ### 2. Check existing localizations
@@ -300,7 +300,8 @@ asc subscriptions list --group-id "GROUP_ID" --paginate
 - When the user provides translated names per locale, use the locale-specific name for each.
 - If a description is provided, pass `--description` on create. Otherwise omit it.
 - Use `--output table` for verification steps so the user can visually confirm.
-- Use default JSON output for intermediate automation steps.
+- Use explicit `--output json` for intermediate automation steps; output
+  defaults are TTY-aware.
 - After bulk creation, always run the list command to verify completeness.
 - For apps with many subscriptions, process them sequentially per group to keep output readable.
 - If a create call fails for a locale, log the locale and error, then continue with the remaining locales. After the batch completes, report all failures together so the user can address them.

--- a/skills/asc-subscription-localization/SKILL.md
+++ b/skills/asc-subscription-localization/SKILL.md
@@ -35,11 +35,16 @@ asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_S
 asc subscriptions groups versions list --group-id "GROUP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output table
 ```
 
-Create a version only when the requested review lifecycle needs a new one:
+Branch independently on each list result: zero matches means create, one means
+reuse that version ID, and more than one means stop and require an explicit
+version ID. Run each command below only for its zero-match branch:
 
 ```bash
+# If and only if the IAP version list returned zero matches:
 asc iap versions create --iap-id "IAP_ID" --output json
+# If and only if the subscription version list returned zero matches:
 asc subscriptions versions create --subscription-id "SUB_ID" --output json
+# If and only if the group version list returned zero matches:
 asc subscriptions groups versions create --group-id "GROUP_ID" --output json
 ```
 


### PR DESCRIPTION
## What changed

This updates the workflow skills for the App Store Connect API 4.4.1 surface
that is now on CLI `main`:

- `asc-id-resolver` keeps product IDs separate from IAP, subscription, and
  subscription-group version IDs, and requests JSON explicitly in automation.
- `asc-subscription-localization` now teaches only version-scoped localization
  workflows for new work. The deprecated product- and group-scoped examples
  were removed.
- `asc-release-flow` and `asc-submission-health` prepare and read back version
  metadata, then add `inAppPurchaseVersions`, `subscriptionVersions`, and
  `subscriptionGroupVersions` to an existing review submission. First-review
  web-session guidance remains separate.
- `asc-ppp-pricing` covers adjusted equalizations with the live-required
  upfront price point and plan type.
- `asc-ppp-pricing` and `asc-revenuecat-catalog-sync` no longer pass deprecated
  localization flags through `setup`. They finish localization through v2
  versions and defer subscription verification until those resources exist.
- `asc-revenuecat-catalog-sync` now fully resolves and reuses canonical parent,
  version, and localization IDs before any write, so reruns do not create extra
  non-deletable versions.
- Every create-capable version workflow now selects the unique
  `PREPARE_FOR_SUBMISSION` version, creates only for zero matches, and stops for
  an explicit ID when more than one match exists.
- `asc-submission-health` documents the two age-rating fields added in 4.4.1
  and their prerequisite declarations.

The skills also warn that none of the three version families has a direct
version delete command and that parent deletion is not reliable cleanup for IAP
or subscription versions.

## CLI evidence

Skills base: `rorkai/app-store-connect-cli-skills@4c7b9ce9e7788bdb51758633d5583e386d0f3ea5`

Every command and flag in the changed skills was checked against the binary
built from final CLI `main`:
`rorkai/App-Store-Connect-CLI@9282e82d1feebddaaaa3285c658e6960b8a500f3`.

That main includes the six API resource PRs (#1776-#1781), the age-rating,
adjusted-equalization, positional-argument, and relationship-limit corrections
(#1782-#1785), and the 4.4.1 legacy-resource deprecation transition (#1786).
The CLI now warns on 27 stable and two experimental legacy command leaves while
preserving their behavior for the required compatibility window. PR #1787
restores all 29 deprecated leaves to their immediate parent help with migration
text. PR #1788 closes the final age-rating sparse-update dependency gap, so all
25 combinations that are provably contradictory without server state are
rejected before authentication or HTTP.

## Live App Store Connect verification

Live testing used only the disposable app `6759231657`, with the locally built
CLI and keychain bypass enabled.

- All 47 operations added by the 4.4.1 schema diff received at least one
  successful live response across 37 paths: 29 GET, eight POST, five PATCH, and
  five DELETE operations.
- IAP, subscription, and subscription-group versions were created and read
  back. Their localization and image create/update/read/delete paths were
  exercised, including full upload reservation, asset upload, commit, and
  delivery-state readback for both image families.
- Review-item add, update, and remove behavior was exercised. Apple accepted a
  subscription-group version item; IAP and subscription version attempts
  reached the endpoint and returned the expected readiness rejection when the
  throwaway products lacked review prerequisites.
- The new age-rating fields were mutated with their required prerequisite
  combination, read back, and restored to `false`.
- Adjusted equalizations succeeded only when both an upfront price point and a
  plan type were supplied. The skills now require both for a fresh request.
- Apple rejected empty and JSON-null descriptions for IAP-version and
  subscription-version localizations even though the schema marks the field
  nullable. The skills document the live restriction.
- A compatibility experiment confirmed that the validator's retained v1 reads
  see v2-created localization and image resources with the same IDs, so no
  runtime validator migration was needed.

Temporary images, secondary localizations, subscription groups, products, and
review items were removed where the API permits it. The age-rating declaration
was restored and the review submission was left empty. Apple did not cascade
two IAP/subscription parent deletions and does not expose a version delete
endpoint, so these throwaway remnants remain recorded:

- IAP version `07d9113f-2a96-43d0-8399-914deeaa49d4` and required localization
  `0073ad1d-879d-41f4-bb7d-49c73f0479b5`
- Subscription version `6f861af5-23c9-4e3c-807a-9879220c051f` and required
  localization `9fc52d69-2eed-440c-8053-0646de35daa8`
- Subscription version `1dcba57e-f03f-49e0-a24e-d048fb6dd479` and required
  localization `67326a94-973a-4061-a991-dc7061018232`

No review submission was submitted, and no CLI or skills release was created.

## Checks

- All 23 repository skills passed the official skill-creator
  `quick_validate.py` with PyYAML 6.0.3.
- 245 documented command examples and 716 flags passed exact help validation
  against the final CLI command surface.
- Deprecated product-scoped localization and submit commands no longer appear
  as runnable examples in the skills.
- Markdown fences are balanced and `git diff --check` passes.

`npx skills` 1.5.19 has no `validate` command; its help lists install, use,
remove, list, find, update, init, and experimental sync operations. It is not a
validator for this repository.
