### PR TITLE
docs: align RevenueCat sync examples with API 4.4.1 flow

### DIFF
--- a/skills/asc-revenuecat-catalog-sync/examples.md
+++ b/skills/asc-revenuecat-catalog-sync/examples.md
@@ -31,20 +31,53 @@ Goal: bootstrap both systems when store products are partially missing.
 `Ensure monthly and annual subscriptions exist in ASC for app APP_ID, then sync them to RevenueCat project PROJECT_ID under my iOS app.`
 
 ### Expected behavior
-1. Audit existing resources first.
-2. If missing in ASC:
-   - create group:
-     - `asc subscriptions groups create --app "APP_ID" --reference-name "Premium"`
-   - create subscriptions:
-     - `asc subscriptions create --group-id "GROUP_ID" --reference-name "Monthly" --product-id "com.example.premium.monthly" --subscription-period ONE_MONTH`
-     - `asc subscriptions create --group-id "GROUP_ID" --reference-name "Annual" --product-id "com.example.premium.annual" --subscription-period ONE_YEAR`
-3. Re-read ASC to capture authoritative IDs.
-4. In RevenueCat:
+1. Audit both catalogs, present the no-write plan, and request confirmation.
+2. Resolve the ASC parents by exact identifiers with fully paginated reads:
+   - `asc subscriptions groups list --app "APP_ID" --paginate --output json`
+   - `asc subscriptions list --group-id "GROUP_ID" --paginate --output json`
+   - zero exact matches means create, one means reuse its ID, and more than one
+     means stop for an explicit ID. Follow [Step D](SKILL.md#step-d---ensure-missing-asc-items-if-requested)
+     for every parent and mutable version; never create another resource to
+     resolve ambiguity.
+3. For a missing subscription, use setup to reconcile its review screenshot,
+   complete price matrix, and requested sale availability before version
+   metadata. Repeat with the annual product ID and `ONE_YEAR`:
+
+   ```bash
+   asc subscriptions setup \
+     --app "APP_ID" \
+     --group-id "GROUP_ID" \
+     --reference-name "Monthly" \
+     --product-id "com.example.premium.monthly" \
+     --subscription-period ONE_MONTH \
+     --review-screenshot "./review.png" \
+     --price "3.99" \
+     --price-territory "USA" \
+     --territories "USA" \
+     --no-verify \
+     --output json
+   ```
+
+   Reuse an existing subscription unless the user explicitly approves its
+   reconciliation. Use `--repair` only when the same setup inputs must rebuild
+   a stale complete price matrix.
+4. Resolve zero/one/many `PREPARE_FOR_SUBMISSION` group and subscription
+   versions, then create or update their version-scoped localizations as shown
+   in Step D. Read back the selected versions and gate all subscriptions before
+   any RevenueCat write:
+
+   ```bash
+   mkdir -p "./audit"
+   asc validate subscriptions --app "APP_ID" --strict --output json --pretty \
+     > "./audit/subscriptions-validation.json"
+   ```
+
+5. Only after the validator exits zero, apply the confirmed RevenueCat plan:
    - create app if missing (`type: app_store`, same bundle identifier)
    - create products with matching `store_identifier`
    - create entitlement (for example `premium`) and attach products
    - optionally create `default` offering with `$rc_monthly` and `$rc_annual`
-5. Verify with final summary and failures list.
+6. Re-read both catalogs and return the final summary and failures list.
 
 ## Example 3: Sync one-time IAP and keep consumables entitlement-free
 
@@ -54,17 +87,55 @@ Goal: model recommended entitlement behavior by product type.
 `Sync my non-consumable lifetime IAP and consumable coin pack to RevenueCat.`
 
 ### Expected behavior
-1. Confirm product type mapping:
+1. Audit both catalogs, confirm product type mapping, present the plan, and
+   request confirmation:
    - `NON_CONSUMABLE` -> `non_consumable`
    - `CONSUMABLE` -> `consumable`
-2. Create missing ASC IAPs if requested:
-   - `asc iap create --app "APP_ID" --type NON_CONSUMABLE --ref-name "Lifetime" --product-id "com.example.lifetime"`
-   - `asc iap create --app "APP_ID" --type CONSUMABLE --ref-name "Coins 100" --product-id "com.example.coins.100"`
-3. In RevenueCat:
+2. Resolve each IAP by exact `productId` with
+   `asc iap list --app "APP_ID" --paginate --output json`. Zero exact matches
+   means create, one means reuse its ID, and more than one means stop for an
+   explicit `IAP_ID`. For a missing IAP, create only the parent; repeat with
+   `CONSUMABLE` and the coin product ID:
+
+   ```bash
+   asc iap create \
+     --app "APP_ID" \
+     --type NON_CONSUMABLE \
+     --ref-name "Lifetime" \
+     --product-id "com.example.lifetime" \
+     --output json
+   ```
+
+3. For every resolved IAP, reconcile pricing and availability, then resolve
+   zero/one/many mutable versions and finish version-scoped localization and
+   review-image metadata. The create commands are conditional on a zero-match
+   read; update or do nothing for an existing match:
+
+   ```bash
+   asc iap pricing summary --iap-id "IAP_ID" --output json
+   asc iap pricing schedules create --iap-id "IAP_ID" --base-territory "USA" --prices "PRICE_POINT_ID" --output json
+   asc iap pricing availability set --iap-id "IAP_ID" --territories "USA" --output json
+   asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+   asc iap versions create --iap-id "IAP_ID" --output json
+   asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output json
+   asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Lifetime" --description "Unlock lifetime access." --output json
+   asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output json
+   asc iap versions images create --version-id "IAP_VERSION_ID" --file "./review.png" --output json
+   ```
+
+4. Gate all resolved IAPs before any RevenueCat creation or attachment:
+
+   ```bash
+   mkdir -p "./audit"
+   asc validate iap --app "APP_ID" --strict --output json --pretty \
+     > "./audit/iap-validation.json"
+   ```
+
+5. Only after the validator exits zero, apply the confirmed RevenueCat plan:
    - create both products
    - attach **non-consumable** product to an entitlement (for example `lifetime_access`)
    - skip entitlement attachment for consumable by default (unless user explicitly asks)
-4. Return created/skipped/failed counts.
+6. Re-read both catalogs and return created/skipped/failed counts.
 
 ## Example 4: Controlled apply in CI-style automation
 
@@ -74,15 +145,21 @@ Goal: make apply mode safe and repeatable in team workflows.
 `Run a full sync and apply missing resources.`
 
 ### Expected behavior
-1. Run audit and print plan.
-2. Request explicit approval.
-3. Apply in deterministic order:
-   - ASC group/subscription/IAP
-   - RC app/product
+1. Run the fully paginated ASC and RevenueCat audit and print a no-write plan.
+2. Request explicit approval before any ASC or RevenueCat create/update.
+3. Apply each approved item in deterministic order:
+   - resolve ASC parents and mutable versions with the zero/one/many rules in
+     Step D
+   - reconcile version-scoped metadata, review screenshots/images, pricing,
+     and availability
+   - save and require a zero exit from `asc validate subscriptions --app "APP_ID" --strict --output json --pretty` and/or `asc validate iap --app "APP_ID" --strict --output json --pretty`
+   - RC app/product, but only for items whose applicable ASC gate passed
    - RC entitlement + attachments
    - RC offering/package + attachments
-4. Continue after item failures and aggregate errors.
-5. Print machine-readable summary plus human-readable recap.
+4. Continue after per-item failures, but never map an item whose ASC gate
+   failed; aggregate every error.
+5. Re-read both systems and print a machine-readable summary plus a
+   human-readable recap.
 
 ## Suggested natural-language prompts for MCP
 

--- a/skills/asc-revenuecat-catalog-sync/examples.md
+++ b/skills/asc-revenuecat-catalog-sync/examples.md
@@ -39,9 +39,9 @@ Goal: bootstrap both systems when store products are partially missing.
      means stop for an explicit ID. Follow [Step D](SKILL.md#step-d---ensure-missing-asc-items-if-requested)
      for every parent and mutable version; never create another resource to
      resolve ambiguity.
-3. For a missing subscription, use setup to reconcile its review screenshot,
-   complete price matrix, and requested sale availability before version
-   metadata. Repeat with the annual product ID and `ONE_YEAR`:
+3. For each missing subscription, use its own setup inputs to reconcile the
+   review screenshot, complete price matrix, and requested sale availability
+   before version metadata:
 
    ```bash
    asc subscriptions setup \
@@ -50,8 +50,21 @@ Goal: bootstrap both systems when store products are partially missing.
      --reference-name "Monthly" \
      --product-id "com.example.premium.monthly" \
      --subscription-period ONE_MONTH \
-     --review-screenshot "./review.png" \
+     --review-screenshot "./monthly-review.png" \
      --price "3.99" \
+     --price-territory "USA" \
+     --territories "USA" \
+     --no-verify \
+     --output json
+
+   asc subscriptions setup \
+     --app "APP_ID" \
+     --group-id "GROUP_ID" \
+     --reference-name "Annual" \
+     --product-id "com.example.premium.annual" \
+     --subscription-period ONE_YEAR \
+     --review-screenshot "./annual-review.png" \
+     --price "39.99" \
      --price-territory "USA" \
      --territories "USA" \
      --no-verify \
@@ -63,8 +76,10 @@ Goal: bootstrap both systems when store products are partially missing.
    a stale complete price matrix.
 4. Resolve zero/one/many `PREPARE_FOR_SUBMISSION` group and subscription
    versions, then create or update their version-scoped localizations as shown
-   in Step D. Read back the selected versions and gate all subscriptions before
-   any RevenueCat write:
+   in Step D. Use `Premium Monthly` with a monthly-specific description for the
+   monthly version and `Premium Annual` with an annual-specific description for
+   the annual version. Read back both selected versions and gate all
+   subscriptions before any RevenueCat write:
 
    ```bash
    mkdir -p "./audit"
@@ -94,8 +109,7 @@ Goal: model recommended entitlement behavior by product type.
 2. Resolve each IAP by exact `productId` with
    `asc iap list --app "APP_ID" --paginate --output json`. Zero exact matches
    means create, one means reuse its ID, and more than one means stop for an
-   explicit `IAP_ID`. For a missing IAP, create only the parent; repeat with
-   `CONSUMABLE` and the coin product ID:
+   explicit `IAP_ID`. For each missing IAP, create only its own parent:
 
    ```bash
    asc iap create \
@@ -104,26 +118,65 @@ Goal: model recommended entitlement behavior by product type.
      --ref-name "Lifetime" \
      --product-id "com.example.lifetime" \
      --output json
+
+   asc iap create \
+     --app "APP_ID" \
+     --type CONSUMABLE \
+     --ref-name "Coins 100" \
+     --product-id "com.example.coins.100" \
+     --output json
    ```
 
-3. For every resolved IAP, reconcile pricing and availability, then resolve
-   zero/one/many mutable versions and finish version-scoped localization and
-   review-image metadata. The create commands are conditional on a zero-match
-   read; update or do nothing for an existing match:
+3. Audit pricing and availability separately for each resolved IAP before
+   reconciling either one:
 
    ```bash
-   asc iap pricing summary --iap-id "IAP_ID" --output json
-   asc iap pricing schedules create --iap-id "IAP_ID" --base-territory "USA" --prices "PRICE_POINT_ID" --output json
-   asc iap pricing availability set --iap-id "IAP_ID" --territories "USA" --output json
-   asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
-   asc iap versions create --iap-id "IAP_ID" --output json
-   asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output json
-   asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Lifetime" --description "Unlock lifetime access." --output json
-   asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output json
-   asc iap versions images create --version-id "IAP_VERSION_ID" --file "./review.png" --output json
+   asc iap pricing summary --iap-id "LIFETIME_IAP_ID" --output json
+   asc iap pricing availability view --iap-id "LIFETIME_IAP_ID" --output json
+   asc iap pricing summary --iap-id "COINS_IAP_ID" --output json
+   asc iap pricing availability view --iap-id "COINS_IAP_ID" --output json
    ```
 
-4. Gate all resolved IAPs before any RevenueCat creation or attachment:
+   Only an App Store Connect `404` from the pricing summary proves that a price
+   schedule is absent. Stop and report authentication, transport, decoding, and
+   every other summary error. After confirmation, create a missing schedule or
+   set availability only when the corresponding successful read proves the
+   desired per-product value differs:
+
+   ```bash
+   asc iap pricing schedules create --iap-id "LIFETIME_IAP_ID" --base-territory "USA" --prices "LIFETIME_PRICE_POINT_ID" --output json
+   asc iap pricing availability set --iap-id "LIFETIME_IAP_ID" --territories "USA" --output json
+   asc iap pricing schedules create --iap-id "COINS_IAP_ID" --base-territory "USA" --prices "COINS_PRICE_POINT_ID" --output json
+   asc iap pricing availability set --iap-id "COINS_IAP_ID" --territories "USA" --output json
+   ```
+
+4. Resolve zero/one/many mutable versions and finish each product's own
+   version-scoped localization and review image. Every create below is
+   conditional on the preceding fully paginated read returning zero matches:
+
+   ```bash
+   asc iap versions list --iap-id "LIFETIME_IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+   asc iap versions create --iap-id "LIFETIME_IAP_ID" --output json
+   asc iap versions localizations list --version-id "LIFETIME_VERSION_ID" --paginate --output json
+   asc iap versions localizations create --version-id "LIFETIME_VERSION_ID" --locale "en-US" --name "Lifetime" --description "Unlock lifetime access." --output json
+   asc iap versions images list --version-id "LIFETIME_VERSION_ID" --paginate --output json
+   asc iap versions images create --version-id "LIFETIME_VERSION_ID" --file "./lifetime-review.png" --output json
+
+   asc iap versions list --iap-id "COINS_IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+   asc iap versions create --iap-id "COINS_IAP_ID" --output json
+   asc iap versions localizations list --version-id "COINS_VERSION_ID" --paginate --output json
+   asc iap versions localizations create --version-id "COINS_VERSION_ID" --locale "en-US" --name "Coins 100" --description "Add 100 coins." --output json
+   asc iap versions images list --version-id "COINS_VERSION_ID" --paginate --output json
+   asc iap versions images create --version-id "COINS_VERSION_ID" --file "./coins-100-review.png" --output json
+   ```
+
+   Update an existing localization only when its resolved values differ. For an
+   image, zero matches means upload and one proven matching image means reuse.
+   More than one match, a differing image, or an image that cannot be proven to
+   match must stop and be reported: `images update` changes upload state only,
+   it cannot replace the file, and this workflow never deletes resources.
+
+5. Gate all resolved IAPs before any RevenueCat creation or attachment:
 
    ```bash
    mkdir -p "./audit"
@@ -131,11 +184,11 @@ Goal: model recommended entitlement behavior by product type.
      > "./audit/iap-validation.json"
    ```
 
-5. Only after the validator exits zero, apply the confirmed RevenueCat plan:
+6. Only after the validator exits zero, apply the confirmed RevenueCat plan:
    - create both products
    - attach **non-consumable** product to an entitlement (for example `lifetime_access`)
    - skip entitlement attachment for consumable by default (unless user explicitly asks)
-6. Re-read both catalogs and return created/skipped/failed counts.
+7. Re-read both catalogs and return created/skipped/failed counts.
 
 ## Example 4: Controlled apply in CI-style automation
 
@@ -150,8 +203,14 @@ Goal: make apply mode safe and repeatable in team workflows.
 3. Apply each approved item in deterministic order:
    - resolve ASC parents and mutable versions with the zero/one/many rules in
      Step D
-   - reconcile version-scoped metadata, review screenshots/images, pricing,
-     and availability
+   - preserve each product's own identifiers, names, periods, prices, locales,
+     and image paths; never reuse one product's template values for another
+   - reconcile version-scoped metadata and review screenshots/images; upload a
+     missing image, reuse a proven match, and stop on a differing or ambiguous
+     image because this no-delete workflow cannot replace it
+   - read IAP pricing summary and availability separately; only a summary `404`
+     means no schedule, every other error stops that item, and availability is
+     set only when a successful read proves the approved territory set differs
    - save and require a zero exit from `asc validate subscriptions --app "APP_ID" --strict --output json --pretty` and/or `asc validate iap --app "APP_ID" --strict --output json --pretty`
    - RC app/product, but only for items whose applicable ASC gate passed
    - RC entitlement + attachments

--- a/skills/asc-revenuecat-catalog-sync/examples.md
+++ b/skills/asc-revenuecat-catalog-sync/examples.md
@@ -44,6 +44,9 @@ Goal: bootstrap both systems when store products are partially missing.
    before version metadata:
 
    ```bash
+   # CONDITIONAL PSEUDOCODE: audit each exact productId, then run only its branch.
+   # Monthly: zero matches -> create with setup; one -> reuse its SUB_ID or run
+   # these same inputs only for explicitly approved reconciliation; many -> stop.
    asc subscriptions setup \
      --app "APP_ID" \
      --group-id "GROUP_ID" \
@@ -57,6 +60,8 @@ Goal: bootstrap both systems when store products are partially missing.
      --no-verify \
      --output json
 
+   # Annual: zero matches -> create with setup; one -> reuse its SUB_ID or run
+   # these same inputs only for explicitly approved reconciliation; many -> stop.
    asc subscriptions setup \
      --app "APP_ID" \
      --group-id "GROUP_ID" \

--- a/skills/asc-revenuecat-catalog-sync/examples.md
+++ b/skills/asc-revenuecat-catalog-sync/examples.md
@@ -133,15 +133,25 @@ Goal: model recommended entitlement behavior by product type.
    ```bash
    asc iap pricing summary --iap-id "LIFETIME_IAP_ID" --output json
    asc iap pricing availability view --iap-id "LIFETIME_IAP_ID" --output json
+   # On a successful parent view, capture .data.id, then:
+   asc iap pricing availabilities available-territories --id "LIFETIME_AVAILABILITY_ID" --paginate --output json
    asc iap pricing summary --iap-id "COINS_IAP_ID" --output json
    asc iap pricing availability view --iap-id "COINS_IAP_ID" --output json
+   # On a successful parent view, capture .data.id, then:
+   asc iap pricing availabilities available-territories --id "COINS_AVAILABILITY_ID" --paginate --output json
    ```
 
    Only an App Store Connect `404` from the pricing summary proves that a price
    schedule is absent. Stop and report authentication, transport, decoding, and
-   every other summary error. After confirmation, create a missing schedule or
-   set availability only when the corresponding successful read proves the
-   desired per-product value differs:
+   every other summary error. For availability, capture `.data.id` from each
+   successful parent view and use it for the fully paginated territory read. A
+   parent-view `404` means availability is missing; every other parent or
+   territory-read error stops that item. Do not infer the territory set from
+   parent-view relationship data because that relationship is optional and may
+   be paged. Compare the complete returned territory-ID set with that product's
+   complete approved set, ignoring order.
+   After confirmation, create a missing schedule or set availability only when
+   it is missing or that complete set differs:
 
    ```bash
    asc iap pricing schedules create --iap-id "LIFETIME_IAP_ID" --base-territory "USA" --prices "LIFETIME_PRICE_POINT_ID" --output json
@@ -209,8 +219,12 @@ Goal: make apply mode safe and repeatable in team workflows.
      missing image, reuse a proven match, and stop on a differing or ambiguous
      image because this no-delete workflow cannot replace it
    - read IAP pricing summary and availability separately; only a summary `404`
-     means no schedule, every other error stops that item, and availability is
-     set only when a successful read proves the approved territory set differs
+     means no schedule, and only an availability-parent `404` means missing
+     availability; every other error stops that item
+   - capture the availability ID, fully paginate
+     `asc iap pricing availabilities available-territories --id "AVAILABILITY_ID" --paginate --output json`,
+     and set availability only when it is missing or the complete approved and
+     current territory-ID sets differ
    - save and require a zero exit from `asc validate subscriptions --app "APP_ID" --strict --output json --pretty` and/or `asc validate iap --app "APP_ID" --strict --output json --pretty`
    - RC app/product, but only for items whose applicable ASC gate passed
    - RC entitlement + attachments

--- a/skills/asc-revenuecat-catalog-sync/examples.md
+++ b/skills/asc-revenuecat-catalog-sync/examples.md
@@ -154,10 +154,18 @@ Goal: model recommended entitlement behavior by product type.
    it is missing or that complete set differs:
 
    ```bash
+   # CONDITIONAL PSEUDOCODE: do not run this block as a sequence.
+   # If the lifetime pricing summary returned the confirmed missing-schedule 404:
    asc iap pricing schedules create --iap-id "LIFETIME_IAP_ID" --base-territory "USA" --prices "LIFETIME_PRICE_POINT_ID" --output json
+   # If lifetime availability is missing or its complete territory set differs:
    asc iap pricing availability set --iap-id "LIFETIME_IAP_ID" --territories "USA" --output json
+   # Otherwise reuse the matching lifetime pricing and availability.
+
+   # If the coin pricing summary returned the confirmed missing-schedule 404:
    asc iap pricing schedules create --iap-id "COINS_IAP_ID" --base-territory "USA" --prices "COINS_PRICE_POINT_ID" --output json
+   # If coin availability is missing or its complete territory set differs:
    asc iap pricing availability set --iap-id "COINS_IAP_ID" --territories "USA" --output json
+   # Otherwise reuse the matching coin pricing and availability.
    ```
 
 4. Resolve zero/one/many mutable versions and finish each product's own
@@ -165,18 +173,27 @@ Goal: model recommended entitlement behavior by product type.
    conditional on the preceding fully paginated read returning zero matches:
 
    ```bash
+   # CONDITIONAL PSEUDOCODE: audit each list, then run only its matching branch.
    asc iap versions list --iap-id "LIFETIME_IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+   # If zero versions, create; if one, reuse; if more than one, stop:
    asc iap versions create --iap-id "LIFETIME_IAP_ID" --output json
    asc iap versions localizations list --version-id "LIFETIME_VERSION_ID" --paginate --output json
+   # If zero localizations, create; if one differs, update it by its resolved ID;
+   # if one matches, reuse; if more than one, stop:
    asc iap versions localizations create --version-id "LIFETIME_VERSION_ID" --locale "en-US" --name "Lifetime" --description "Unlock lifetime access." --output json
    asc iap versions images list --version-id "LIFETIME_VERSION_ID" --paginate --output json
+   # If zero images, upload; if one proven match, reuse; otherwise stop:
    asc iap versions images create --version-id "LIFETIME_VERSION_ID" --file "./lifetime-review.png" --output json
 
    asc iap versions list --iap-id "COINS_IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
+   # If zero versions, create; if one, reuse; if more than one, stop:
    asc iap versions create --iap-id "COINS_IAP_ID" --output json
    asc iap versions localizations list --version-id "COINS_VERSION_ID" --paginate --output json
+   # If zero localizations, create; if one differs, update it by its resolved ID;
+   # if one matches, reuse; if more than one, stop:
    asc iap versions localizations create --version-id "COINS_VERSION_ID" --locale "en-US" --name "Coins 100" --description "Add 100 coins." --output json
    asc iap versions images list --version-id "COINS_VERSION_ID" --paginate --output json
+   # If zero images, upload; if one proven match, reuse; otherwise stop:
    asc iap versions images create --version-id "COINS_VERSION_ID" --file "./coins-100-review.png" --output json
    ```
 
@@ -225,8 +242,16 @@ Goal: make apply mode safe and repeatable in team workflows.
      `asc iap pricing availabilities available-territories --id "AVAILABILITY_ID" --paginate --output json`,
      and set availability only when it is missing or the complete approved and
      current territory-ID sets differ
-   - save and require a zero exit from `asc validate subscriptions --app "APP_ID" --strict --output json --pretty` and/or `asc validate iap --app "APP_ID" --strict --output json --pretty`
-   - RC app/product, but only for items whose applicable ASC gate passed
+   - when subscriptions exist in the plan, save and run
+     `asc validate subscriptions --app "APP_ID" --strict --output json --pretty`;
+     map no subscriptions unless this subscription-class gate exits zero
+   - when IAPs exist in the plan, save and run
+     `asc validate iap --app "APP_ID" --strict --output json --pretty`; map no
+     IAPs unless this IAP-class gate exits zero
+   - when both classes exist, run both validators; a failed class is skipped,
+     the other class may continue only if its own gate exits zero, and all gate
+     and per-item failures are aggregated
+   - RC app/product for items in each successfully gated class
    - RC entitlement + attachments
    - RC offering/package + attachments
 4. Continue after per-item failures, but never map an item whose ASC gate


### PR DESCRIPTION
## Summary

- align RevenueCat catalog-sync Examples 2-4 with the canonical API 4.4.1 workflow
- require zero/one/many parent and mutable-version resolution before conditional writes
- finish version-scoped metadata plus screenshot/image, pricing, and availability reconciliation before RevenueCat mapping
- preserve audit-before-write confirmation and add strict subscription/IAP validator gates

## Evidence

- ASC CLI source: `d6d8d94bd532d7e9ce80d3147ed4e521479de75a`
- skills base: `e5561a9a1795052a68a9c581c571adb6b5d1c459`
- exact-help validator: `commands=13 flags=53 failures=0`
- skill-creator `quick_validate.py`: `Skill is valid!`
- `git diff --check`: pass

Documentation-only; no live App Store Connect or RevenueCat resources were mutated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “asc RevenueCat catalog sync” guide’s examples with stricter, fully paginated reconciliation workflows.
  * Added clearer validation gates (strict mode) that must pass before any RevenueCat changes are applied.
  * Clarified deterministic identifier resolution with explicit ambiguity handling.
  * Improved pricing vs. availability processing with precise missing/mismatch semantics and conditional updates.
  * Made the automation workflow safer and more predictable with explicit approval, per-item failure aggregation, and post-apply re-reading/reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->