### PR TITLE
docs: fix xcode help paths

### DIFF
--- a/skills/asc-xcode-build/SKILL.md
+++ b/skills/asc-xcode-build/SKILL.md
@@ -129,7 +129,9 @@ For `.pkg` uploads, `--version` and `--build-number` are required because they a
 
 ## Raw xcodebuild fallback
 
-Use raw `xcodebuild` only when `asc xcode archive/export --help` does not cover a project-specific option. Prefer passing extra arguments through `--xcodebuild-flag` first.
+Use raw `xcodebuild` only when neither `asc xcode archive --help` nor
+`asc xcode export --help` covers a project-specific option. Prefer passing
+extra arguments through `--xcodebuild-flag` first.
 
 ```bash
 xcodebuild -showBuildSettings -scheme "App"


### PR DESCRIPTION
## Summary
- replace the nonexistent combined `asc xcode archive/export --help` path
- point agents to the separate archive and export help commands

## Evidence
Validated against App-Store-Connect-CLI `48e0d003ebde8d2046b0a19463526c95c3bc25e4`:
- `asc xcode archive --help`
- `asc xcode export --help`
- skill-creator `quick_validate.py`: 23/23 skills pass
- full skills command inventory: 695 runnable command occurrences, 489 unique commands, 231 help paths, and 1,651 long-flag occurrences; zero command/help/flag failures

No CLI behavior or App Store Connect resources are changed by this documentation-only PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified when to use raw `xcodebuild` as a fallback.
  - Recommended forwarding additional build arguments through supported command options before using raw commands.
  - Updated guidance to check archive and export help separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->