### PR TITLE
docs(xcode): sync skills with asc 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ Create a new App Store Connect app for com.example.myapp with SKU MYAPP123 and p
 
 ### asc-xcode-build
 
-Build, archive, export, and manage Xcode version/build numbers before uploading.
+Build, archive, generate export options, export, and manage Xcode version/build numbers before uploading.
 
 **Use when:**
 - You need to create an IPA or PKG for upload
 - You're setting up CI/CD build pipelines
-- You need to configure ExportOptions.plist
+- You need to generate or customize ExportOptions.plist
 - You're troubleshooting encryption compliance issues
 
 **Example:**

--- a/skills/asc-xcode-build/SKILL.md
+++ b/skills/asc-xcode-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asc-xcode-build
-description: Build, archive, export, upload, and manage Xcode version/build numbers with the current asc xcode helpers before App Store Connect upload or submission. Use when creating an IPA or PKG for upload.
+description: Build, archive, generate export options, export, upload, and manage Xcode version/build numbers with the current asc xcode helpers before App Store Connect upload or submission. Use when creating an IPA or PKG for upload.
 ---
 
 # Xcode build and export
@@ -18,18 +18,21 @@ Use this skill when you need to build an app from source and prepare it for App 
 ```bash
 asc xcode version view
 asc xcode version edit --version "1.3.0" --build-number "42"
+asc xcode version edit --next-build-number --app "APP_ID" --platform IOS
 asc xcode version bump --type build
 asc xcode version bump --type patch
+asc xcode version bump --type build --next-build-number --app "APP_ID" --platform IOS
 ```
 
-Use `--project-dir "./MyApp"` when not running from the project root. Use `--project "./MyApp/App.xcodeproj"` when the directory contains multiple projects. Use `--target "App"` for deterministic reads in multi-target projects.
+Use `--project-dir "./MyApp"` when not running from the project root. Use `--project "./MyApp/App.xcodeproj"` when the directory contains multiple projects. Use `--target "App"` and `--configuration "Release"` for deterministic reads and writes in multi-target or multi-configuration projects.
 
-To avoid low build-number rejects, resolve a remote-safe build number first:
+To avoid low build-number rejects, resolve and apply the remote-safe build number in one command:
 
 ```bash
-asc builds next-build-number --app "APP_ID" --version "1.2.3" --platform IOS --output json
-asc xcode version edit --build-number "NEXT_BUILD"
+asc xcode version edit --next-build-number --app "APP_ID" --platform IOS --output json
 ```
+
+Version mutations validate the full change before writing and return structured output identifying the configurations and files changed. The editor follows recursive xcconfig includes and preserves unrelated project and xcconfig content. Use `asc builds next-build-number` separately when you only want to inspect the remote-safe value without changing the project.
 
 ## Preferred iOS/tvOS/visionOS build flow
 
@@ -51,21 +54,32 @@ Use `--project "App.xcodeproj"` instead of `--workspace` for project-only apps.
 
 ### 2. Export with asc
 
+By default, `asc xcode export` generates App Store Connect export options with automatic signing. It uses a local export destination unless `--wait` is set, in which case it uses direct upload:
+
 ```bash
 asc xcode export \
   --archive-path ".asc/artifacts/App.xcarchive" \
-  --export-options "ExportOptions.plist" \
   --ipa-path ".asc/artifacts/App.ipa" \
   --xcodebuild-flag=-allowProvisioningUpdates \
   --output json
 ```
 
-If `ExportOptions.plist` uses direct App Store Connect upload, add `--wait` to poll for build discovery and processing:
+Generate a plist separately when it needs review, reuse, or manual signing:
+
+```bash
+asc xcode export-options generate \
+  --archive-path ".asc/artifacts/App.xcarchive" \
+  --output-path ".asc/ExportOptions.plist" \
+  --output json
+```
+
+For manual signing, add `--signing-style manual` and optionally `--team-id "TEAM_ID"`. Existing files require `--overwrite`.
+
+To upload directly through Xcode and wait for App Store Connect processing, omit `--export-options` and add `--wait`:
 
 ```bash
 asc xcode export \
   --archive-path ".asc/artifacts/App.xcarchive" \
-  --export-options "UploadExportOptions.plist" \
   --ipa-path ".asc/artifacts/App.ipa" \
   --wait \
   --output json
@@ -148,8 +162,7 @@ xcodebuild -showBuildSettings -scheme "App"
 ### CFBundleVersion too low
 
 ```bash
-asc builds next-build-number --app "APP_ID" --version "1.2.3" --platform IOS
-asc xcode version edit --build-number "NEXT_BUILD"
+asc xcode version edit --next-build-number --app "APP_ID" --platform IOS
 ```
 
 Then rebuild and upload again.


### PR DESCRIPTION
## Summary
- document asc xcode export-options generate
- use automatic ExportOptions generation in the default export workflow
- document direct remote-safe version edits and build bumps
- refresh the README skill catalog entry

## CLI evidence
Validated against ASC CLI 3.1.0 at commit 71edb97dbd85fc1b7f8ea91b873f3e40549347dd.

Checked live help for:
- asc xcode
- asc xcode version view, edit, and bump
- asc xcode export-options generate
- asc xcode archive and export

## Validation
- all six changed command examples parse with --help against the released 3.1.0 binary
- git diff --check
- YAML frontmatter, folder names, descriptions, and Markdown fence balance validated across all 23 skills

The published skills CLI currently has no validate command, and the bundled quick_validate.py cannot run because PyYAML is absent, so those are reported rather than treated as passing validators.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/app-store-connect-cli-skills/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786914813&installation_id=101311810&pr_number=53&repository=rorkai%2Fapp-store-connect-cli-skills&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2Fapp-store-connect-cli-skills%2Fpull%2F53&signature=0fc6dc716edd50c5962b4ee8e1f63c407d4572aae03a865e3a9f46da377b08b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->