### PR TITLE
Package ASC skills for Codex and Claude Code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "rorkai",
+  "owner": {
+    "name": "Rork"
+  },
+  "description": "Agent skills and tooling for App Store Connect workflows.",
+  "plugins": [
+    {
+      "name": "asc",
+      "source": "./"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "asc",
+  "displayName": "App Store Connect CLI Skills",
+  "version": "1.0.0",
+  "description": "Production workflows for shipping apps with the unofficial App Store Connect CLI, including builds, TestFlight, metadata, submissions, signing, screenshots, and Apple Ads.",
+  "author": {
+    "name": "Rudrank Riyam",
+    "url": "https://github.com/rudrankriyam"
+  },
+  "homepage": "https://github.com/rorkai/app-store-connect-cli-skills",
+  "repository": "https://github.com/rorkai/app-store-connect-cli-skills",
+  "license": "MIT",
+  "keywords": [
+    "app-store-connect",
+    "asc",
+    "ios",
+    "macos",
+    "testflight",
+    "app-store"
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "asc",
+  "version": "1.0.0",
+  "description": "Community-maintained Codex skills for shipping apps with the unofficial asc App Store Connect CLI.",
+  "author": {
+    "name": "Rudrank Riyam",
+    "url": "https://github.com/rudrankriyam"
+  },
+  "homepage": "https://github.com/rorkai/app-store-connect-cli-skills",
+  "repository": "https://github.com/rorkai/app-store-connect-cli-skills",
+  "license": "MIT",
+  "keywords": [
+    "app-store-connect",
+    "asc",
+    "ios",
+    "macos",
+    "testflight",
+    "app-store",
+    "developer-tools"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "App Store Connect CLI",
+    "shortDescription": "Ship apps with the asc CLI",
+    "longDescription": "Use the asc CLI to build and upload apps, manage TestFlight, synchronize App Store metadata, prepare releases, submit versions for review, configure signing, and operate Apple Ads workflows.",
+    "developerName": "Rudrank Riyam",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/rorkai/app-store-connect-cli-skills",
+    "defaultPrompt": [
+      "Prepare and submit my app to App Store review with asc",
+      "Upload this build to TestFlight and distribute it safely",
+      "Audit and sync my App Store metadata with asc"
+    ]
+  }
+}

--- a/.github/workflows/validate-plugin-packaging.yml
+++ b/.github/workflows/validate-plugin-packaging.yml
@@ -24,10 +24,10 @@ jobs:
       SKILLS_REF_VERSION: 0.1.1
     steps:
       - name: Check out repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -53,7 +53,7 @@ jobs:
         run: python -m unittest discover -s tests -p 'test_*.py'
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22"
 

--- a/.github/workflows/validate-plugin-packaging.yml
+++ b/.github/workflows/validate-plugin-packaging.yml
@@ -1,0 +1,98 @@
+name: Validate plugin packaging
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-plugin-packaging-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Skills, Codex, and Claude
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      CLAUDE_CODE_VERSION: 2.1.198
+      CODEX_CLI_VERSION: 0.144.1
+      SKILLS_REF_VERSION: 0.1.1
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Agent Skills validator
+        run: python -m pip install "skills-ref==${SKILLS_REF_VERSION}"
+
+      - name: Validate all Agent Skills
+        shell: bash
+        run: |
+          set -euo pipefail
+          skill_count=0
+          for skill_dir in skills/*; do
+            [[ -d "${skill_dir}" ]] || continue
+            agentskills validate "${skill_dir}"
+            skill_count=$((skill_count + 1))
+          done
+          test "${skill_count}" -eq 23
+
+      - name: Validate cross-host manifests
+        run: python scripts/validate-plugin-packaging.py . --expected-skills 23
+
+      - name: Test packaging validator
+        run: python -m unittest discover -s tests -p 'test_*.py'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+
+      - name: Install pinned host CLIs
+        run: |
+          npm install --global \
+            "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
+            "@openai/codex@${CODEX_CLI_VERSION}"
+
+      - name: Load Codex plugin
+        shell: bash
+        run: |
+          set -euo pipefail
+          asc_codex_marketplace_root="${RUNNER_TEMP}/asc-codex-marketplace"
+          cp -R tests/fixtures/codex-marketplace "${asc_codex_marketplace_root}"
+          mkdir -p "${asc_codex_marketplace_root}/plugins/asc"
+          cp -R .codex-plugin skills "${asc_codex_marketplace_root}/plugins/asc/"
+          codex plugin marketplace add "${asc_codex_marketplace_root}" --json
+          install_json="$(codex plugin add asc@asc-ci --json)"
+          printf '%s\n' "${install_json}"
+          installed_path="$(jq -er '.installedPath' <<<"${install_json}")"
+          test -d "${installed_path}/skills"
+          skill_count="$(find "${installed_path}/skills" -mindepth 2 -maxdepth 2 -type f -name SKILL.md | wc -l | tr -d ' ')"
+          test "${skill_count}" -eq 23
+
+      - name: Validate and load Claude plugin
+        shell: bash
+        run: |
+          set -euo pipefail
+          claude plugin validate .claude-plugin/plugin.json --strict
+          claude plugin validate .claude-plugin/marketplace.json --strict
+          asc_claude_config_dir="${RUNNER_TEMP}/asc-claude-config"
+          mkdir -p "${asc_claude_config_dir}"
+          CLAUDE_CONFIG_DIR="${asc_claude_config_dir}" claude plugin marketplace add ./
+          CLAUDE_CONFIG_DIR="${asc_claude_config_dir}" claude plugin install asc@rorkai
+          details="$(CLAUDE_CONFIG_DIR="${asc_claude_config_dir}" claude plugin details asc@rorkai)"
+          printf '%s\n' "${details}"
+          grep -F "Skills (23)" <<<"${details}"
+
+      # Codex CLI 0.144.1 has no plugin validation subcommand, so its manifest is
+      # checked by the repository validator and loaded from a disposable CI-only
+      # marketplace. No developer marketplace configuration is touched.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -8,16 +8,35 @@ Skills follow the Agent Skills format.
 
 ## Installation
 
-Install this skill pack:
+Install the skills with `asc`:
 
 ```bash
 asc install-skills
 ```
 
-Or install directly from GitHub:
+Or install them directly from GitHub with the Agent Skills installer:
 
 ```bash
 npx skills add rorkai/app-store-connect-cli-skills
+```
+
+### Claude Code plugin
+
+This repository is also a Claude Code marketplace. Add it once, then install the `asc` plugin:
+
+```bash
+claude plugin marketplace add rorkai/app-store-connect-cli-skills
+claude plugin install asc@rorkai
+```
+
+### Codex plugin
+
+The repository includes a Codex plugin manifest and can be listed by a Codex plugin marketplace.
+Codex currently installs plugins from configured marketplaces, so use the Agent Skills installer
+until `asc` has a public marketplace listing:
+
+```bash
+npx skills add rorkai/app-store-connect-cli-skills --agent codex
 ```
 
 ## Available Skills

--- a/scripts/validate-plugin-packaging.py
+++ b/scripts/validate-plugin-packaging.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Validate the cross-host plugin package without requiring either host CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
+
+
+SEMVER = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+KEBAB_CASE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+CODEX_KEYS = {
+    "id",
+    "name",
+    "version",
+    "description",
+    "skills",
+    "apps",
+    "mcpServers",
+    "interface",
+    "author",
+    "homepage",
+    "repository",
+    "license",
+    "keywords",
+}
+CODEX_INTERFACE_KEYS = {
+    "displayName",
+    "shortDescription",
+    "longDescription",
+    "developerName",
+    "category",
+    "capabilities",
+    "websiteURL",
+    "privacyPolicyURL",
+    "termsOfServiceURL",
+    "brandColor",
+    "composerIcon",
+    "logo",
+    "logoDark",
+    "screenshots",
+    "defaultPrompt",
+    "default_prompt",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", nargs="?", default=".", help="Plugin repository root")
+    parser.add_argument(
+        "--expected-skills",
+        type=int,
+        default=23,
+        help="Expected number of packaged skills (default: 23)",
+    )
+    return parser.parse_args()
+
+
+def load_object(path: Path, errors: list[str]) -> dict[str, Any] | None:
+    if not path.is_file():
+        errors.append(f"missing {path}")
+        return None
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        errors.append(f"{path} is not valid JSON: {error}")
+        return None
+    if not isinstance(value, dict):
+        errors.append(f"{path} must contain a JSON object")
+        return None
+    reject_placeholders(value, str(path), errors)
+    return value
+
+
+def reject_placeholders(value: Any, label: str, errors: list[str]) -> None:
+    if isinstance(value, str) and "[TODO:" in value:
+        errors.append(f"{label} contains a TODO placeholder")
+    elif isinstance(value, list):
+        for item in value:
+            reject_placeholders(item, label, errors)
+    elif isinstance(value, dict):
+        for item in value.values():
+            reject_placeholders(item, label, errors)
+
+
+def require_string(payload: dict[str, Any], field: str, label: str, errors: list[str]) -> str | None:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{label}.{field} must be a non-empty string")
+        return None
+    return value
+
+
+def validate_https(payload: dict[str, Any], field: str, label: str, errors: list[str]) -> None:
+    value = payload.get(field)
+    if value is None:
+        return
+    parsed = urlparse(value) if isinstance(value, str) else None
+    if parsed is None or parsed.scheme != "https" or not parsed.netloc:
+        errors.append(f"{label}.{field} must be an absolute HTTPS URL")
+
+
+def validate_identity(payload: dict[str, Any], label: str, errors: list[str]) -> None:
+    name = require_string(payload, "name", label, errors)
+    version = require_string(payload, "version", label, errors)
+    require_string(payload, "description", label, errors)
+    if name is not None and KEBAB_CASE.fullmatch(name) is None:
+        errors.append(f"{label}.name must be lowercase kebab-case")
+    if version is not None and SEMVER.fullmatch(version) is None:
+        errors.append(f"{label}.version must be strict semver")
+
+    author = payload.get("author")
+    if not isinstance(author, dict):
+        errors.append(f"{label}.author must be an object")
+    else:
+        require_string(author, "name", f"{label}.author", errors)
+        validate_https(author, "url", f"{label}.author", errors)
+    for field in ("homepage", "repository"):
+        validate_https(payload, field, label, errors)
+
+
+def validate_relative_directory(root: Path, raw_path: Any, label: str, errors: list[str]) -> Path | None:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        errors.append(f"{label} must be a non-empty relative path")
+        return None
+    posix_path = PurePosixPath(raw_path)
+    if posix_path.is_absolute() or ".." in posix_path.parts:
+        errors.append(f"{label} must stay inside the plugin root")
+        return None
+    resolved = (root / posix_path).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        errors.append(f"{label} must stay inside the plugin root")
+        return None
+    if not resolved.is_dir():
+        errors.append(f"{label} does not resolve to a directory")
+        return None
+    return resolved
+
+
+def validate_codex(root: Path, manifest: dict[str, Any], errors: list[str]) -> None:
+    label = ".codex-plugin/plugin.json"
+    unknown = sorted(set(manifest) - CODEX_KEYS)
+    if unknown:
+        errors.append(f"{label} contains unsupported fields: {', '.join(unknown)}")
+    validate_identity(manifest, label, errors)
+    skills = validate_relative_directory(root, manifest.get("skills"), f"{label}.skills", errors)
+    if skills is not None and skills != (root / "skills").resolve():
+        errors.append(f"{label}.skills must resolve to the root skills directory")
+
+    interface = manifest.get("interface")
+    if not isinstance(interface, dict):
+        errors.append(f"{label}.interface must be an object")
+        return
+    unknown_interface = sorted(set(interface) - CODEX_INTERFACE_KEYS)
+    if unknown_interface:
+        errors.append(f"{label}.interface contains unsupported fields: {', '.join(unknown_interface)}")
+    for field in ("displayName", "shortDescription", "longDescription", "developerName", "category"):
+        require_string(interface, field, f"{label}.interface", errors)
+    capabilities = interface.get("capabilities")
+    if not isinstance(capabilities, list) or not capabilities or not all(
+        isinstance(item, str) and item.strip() for item in capabilities
+    ):
+        errors.append(f"{label}.interface.capabilities must be a non-empty array of strings")
+    prompts = interface.get("defaultPrompt", interface.get("default_prompt"))
+    if not isinstance(prompts, list) or not 1 <= len(prompts) <= 3 or not all(
+        isinstance(item, str) and item.strip() and len(item) <= 128 for item in prompts
+    ):
+        errors.append(f"{label}.interface.defaultPrompt must contain 1-3 non-empty strings of at most 128 characters")
+
+
+def validate_claude(
+    root: Path,
+    manifest: dict[str, Any],
+    marketplace: dict[str, Any],
+    errors: list[str],
+) -> None:
+    label = ".claude-plugin/plugin.json"
+    validate_identity(manifest, label, errors)
+    if manifest.get("$schema") != "https://json.schemastore.org/claude-code-plugin-manifest.json":
+        errors.append(f"{label} must reference the official Claude Code plugin schema")
+    plugin_name = manifest.get("name")
+    plugins = marketplace.get("plugins")
+    if not isinstance(plugins, list):
+        errors.append(".claude-plugin/marketplace.json.plugins must be an array")
+        return
+    matches = [item for item in plugins if isinstance(item, dict) and item.get("name") == plugin_name]
+    if len(matches) != 1:
+        errors.append("Claude marketplace must contain exactly one entry matching the plugin name")
+    elif matches[0].get("source") != "./":
+        errors.append("Claude marketplace plugin source must be `./` so the repository root is loadable")
+
+
+def validate_skills(root: Path, expected: int, errors: list[str]) -> list[Path]:
+    skills_root = root / "skills"
+    if not skills_root.is_dir():
+        errors.append("missing skills directory")
+        return []
+    skill_dirs = sorted(path for path in skills_root.iterdir() if path.is_dir() and not path.name.startswith("."))
+    if len(skill_dirs) != expected:
+        errors.append(f"expected {expected} skills, found {len(skill_dirs)}")
+    for skill_dir in skill_dirs:
+        if not (skill_dir / "SKILL.md").is_file():
+            errors.append(f"skill {skill_dir.name} is missing SKILL.md")
+    return skill_dirs
+
+
+def validate(root: Path, expected_skills: int) -> list[str]:
+    errors: list[str] = []
+    root = root.resolve()
+    skill_dirs = validate_skills(root, expected_skills, errors)
+    codex = load_object(root / ".codex-plugin" / "plugin.json", errors)
+    claude = load_object(root / ".claude-plugin" / "plugin.json", errors)
+    marketplace = load_object(root / ".claude-plugin" / "marketplace.json", errors)
+    if codex is not None:
+        validate_codex(root, codex, errors)
+    if claude is not None and marketplace is not None:
+        validate_claude(root, claude, marketplace, errors)
+    if codex is not None and claude is not None:
+        for field in ("name", "version", "repository", "homepage", "license"):
+            if codex.get(field) != claude.get(field):
+                errors.append(f"Codex and Claude manifests must use the same {field}")
+    if not errors and len(skill_dirs) == expected_skills:
+        print(
+            f"Packaging validation passed: {len(skill_dirs)} skills, "
+            f"Codex {codex.get('name')}, Claude {claude.get('name')}, version {codex.get('version')}"
+        )
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+    errors = validate(Path(args.root), args.expected_skills)
+    if errors:
+        print("Packaging validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/codex-marketplace/.agents/plugins/marketplace.json
+++ b/tests/fixtures/codex-marketplace/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "asc-ci",
+  "interface": {
+    "displayName": "ASC Plugin CI"
+  },
+  "plugins": [
+    {
+      "name": "asc",
+      "source": {
+        "source": "local",
+        "path": "./plugins/asc"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/tests/test_validate_plugin_packaging.py
+++ b/tests/test_validate_plugin_packaging.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "validate-plugin-packaging.py"
+SPEC = importlib.util.spec_from_file_location("validate_plugin_packaging", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATOR)
+
+
+class PackagingValidatorTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        skill = self.root / "skills" / "asc-example"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: asc-example\ndescription: Example\n---\n", encoding="utf-8")
+        self.codex = {
+            "name": "asc",
+            "version": "1.0.0",
+            "description": "Example Codex package",
+            "author": {"name": "Example", "url": "https://example.com"},
+            "homepage": "https://example.com/plugin",
+            "repository": "https://example.com/repository",
+            "license": "MIT",
+            "skills": "./skills/",
+            "interface": {
+                "displayName": "ASC",
+                "shortDescription": "ASC skills",
+                "longDescription": "App Store Connect skills",
+                "developerName": "Example",
+                "category": "Developer Tools",
+                "capabilities": ["Interactive"],
+                "defaultPrompt": ["Prepare my release"],
+            },
+        }
+        self.claude = {
+            "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+            "name": "asc",
+            "version": "1.0.0",
+            "description": "Example Claude package",
+            "author": {"name": "Example", "url": "https://example.com"},
+            "homepage": "https://example.com/plugin",
+            "repository": "https://example.com/repository",
+            "license": "MIT",
+        }
+        self.marketplace = {"name": "example", "plugins": [{"name": "asc", "source": "./"}]}
+        self.write_manifests()
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def write_manifests(self) -> None:
+        for directory, name, payload in (
+            (".codex-plugin", "plugin.json", self.codex),
+            (".claude-plugin", "plugin.json", self.claude),
+            (".claude-plugin", "marketplace.json", self.marketplace),
+        ):
+            path = self.root / directory / name
+            path.parent.mkdir(exist_ok=True)
+            path.write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_valid_cross_host_package(self) -> None:
+        self.assertEqual([], VALIDATOR.validate(self.root, 1))
+
+    def test_rejects_cross_host_version_drift(self) -> None:
+        self.claude["version"] = "1.1.0"
+        self.write_manifests()
+        self.assertIn(
+            "Codex and Claude manifests must use the same version",
+            VALIDATOR.validate(self.root, 1),
+        )
+
+    def test_rejects_cross_host_name_drift(self) -> None:
+        self.codex["name"] = "asc-codex"
+        self.write_manifests()
+        self.assertIn(
+            "Codex and Claude manifests must use the same name",
+            VALIDATOR.validate(self.root, 1),
+        )
+
+    def test_rejects_wrong_skill_count(self) -> None:
+        self.assertIn("expected 2 skills, found 1", VALIDATOR.validate(self.root, 2))
+
+    def test_rejects_non_root_claude_source(self) -> None:
+        self.marketplace["plugins"][0]["source"] = "."
+        self.write_manifests()
+        self.assertIn(
+            "Claude marketplace plugin source must be `./` so the repository root is loadable",
+            VALIDATOR.validate(self.root, 1),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add `asc` 1.0.0 manifests for Codex and Claude Code
- make this repository an installable Claude marketplace
- add pinned CI that validates all 23 Agent Skills and installs the plugin through both hosts
- document Claude installation and the current Codex marketplace boundary

## Why

People already install these as standalone Agent Skills. Host manifests make the same `skills/` tree load as a namespaced plugin without copying any skill content. The short `asc` namespace also avoids repeating the full repository name across all 23 skill descriptions.

## Validation

- all 23 skills pass `skills-ref` 0.1.1
- Codex plugin validator passes
- Codex 0.144.1 installs the package into a disposable marketplace cache with 23 `SKILL.md` files
- Claude Code 2.1.198 passes strict manifest validation and loads 23 skills from an isolated marketplace
- five packaging-validator tests and `actionlint` pass

## Distribution note

Claude can install directly from this repository after merge. Codex currently installs plugins from configured marketplace catalogs, so the existing `npx skills add ... --agent codex` route stays documented until `asc` receives a public Codex marketplace listing. No behavioral eval work is included in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/app-store-connect-cli-skills/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787219832&installation_model_id=10418&pr_number=54&repository=rorkai%2Fapp-store-connect-cli-skills&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2Fapp-store-connect-cli-skills%2Fpull%2F54&signature=5586252c9d83865550c144bb4d19ff103692829a38f612f815a1bc4ade1651dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Claude and Codex plugin manifests, including marketplace definitions for the App Store Connect workflow toolkit.
  - Added a Codex/Claude skill package layout with bundled install behavior.
- **Documentation**
  - Expanded installation guidance with clear command examples for `asc` and third-party agent environments.
- **Quality Improvements**
  - Added an automated packaging validation workflow covering manifests, skills, and cross-platform consistency.
  - Added unit tests for valid packages and common configuration errors.
- **Chores**
  - Updated `.gitignore` to exclude Python cache artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->