### PR TITLE
Separate release orchestration from submission health

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,17 +117,19 @@ Build my iOS app, capture the home and settings screens in the simulator, frame 
 
 ### asc-release-flow
 
-Readiness-first App Store submission guidance, including `asc validate`, `asc release stage`, `asc review submit`, and first-time release blockers.
+Stage, upload, publish, and submit App Store releases through dry-run and confirmation-oriented orchestration.
 
 **Use when:**
-- You want the quickest answer to "can I submit this app now?"
-- You need to separate API-fixable, web-session-fixable, and manual blockers
-- You're handling first-time submission issues around availability, IAPs, subscriptions, Game Center, or App Privacy
+- A prepared app version or artifact needs to be staged, uploaded, or submitted
+- You need to choose between `asc release stage`, `asc review submit`, and `asc publish appstore`
+- You need to assemble a multi-item submission containing Game Center or digital-goods versions
+
+For readiness failures, blocker diagnosis, monitoring, cancellation, or retry decisions, use `asc-submission-health`.
 
 **Example:**
 
 ```bash
-Check whether version 2.4.0 of my iOS app is ready for App Store submission, show the blockers, and tell me the next `asc` command to run.
+Stage version 2.4.0 with the selected build, show the dry-run plan, and submit it after confirmation.
 ```
 
 ### asc-signing-setup
@@ -221,17 +223,20 @@ Turn these release bullet points into polished What's New notes for en-US and lo
 
 ### asc-submission-health
 
-Preflight checks, digital-goods readiness validation, submission, and review monitoring.
+Diagnose submission blockers, route repairs, monitor review state, cancel unhealthy submissions, and decide when to retry.
 
 **Use when:**
-- You want to reduce submission failures
-- You need to track review status and re-submit safely
-- You're troubleshooting "version not in valid state" errors
+- You want to know whether an app can be submitted now
+- Validation reports metadata, compliance, digital-goods, availability, or App Privacy blockers
+- A version is not in a valid state
+- You need to monitor, cancel, repair, or safely retry a submission
+
+For staging, upload, publication, and submission execution, use `asc-release-flow`.
 
 **Example:**
 
 ```bash
-Preflight my iOS submission, check encryption/content-rights issues, and tell me what will block review.
+Validate version 2.4.0, classify every blocker, route the repairs, and tell me whether it is safe to retry.
 ```
 
 ### asc-testflight-orchestration

--- a/README.md
+++ b/README.md
@@ -128,9 +128,7 @@ For readiness failures, blocker diagnosis, monitoring, cancellation, or retry de
 
 **Example:**
 
-```bash
-Stage version 2.4.0 with the selected build, show the dry-run plan, and submit it after confirmation.
-```
+> Stage version 2.4.0 with the selected build, show the dry-run plan, and submit it after confirmation.
 
 ### asc-signing-setup
 

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -16,7 +16,7 @@ This skill owns:
 - submitting a prepared version;
 - assembling a multi-item review submission.
 
-Use [references/multi-item-submissions.md](references/multi-item-submissions.md) for Game Center item preparation or attachment blockers. Stop and use `asc-submission-health` for other validation blockers, a stuck submission, cancellation, or retry decisions.
+Use [the preparation section](references/multi-item-submissions.md#prepare-every-item) for Game Center item preparation or attachment blockers. Use that reference's assembly and submission sections only after the app version is staged and the multi-item lane is selected. Stop and use `asc-submission-health` for other validation blockers, a stuck submission, cancellation, or retry decisions.
 
 ## Preconditions
 
@@ -51,9 +51,11 @@ Use strict mode when warnings must stop automation:
 asc validate --app "APP_ID" --version "1.2.3" --platform IOS --strict --output table
 ```
 
-If the app includes digital goods, use `asc-submission-health` to verify those resources before returning to this flow. If it includes Game Center items, continue with [references/multi-item-submissions.md](references/multi-item-submissions.md), which owns their preparation and attachment.
+Digital goods are a hard gate. If the release includes IAPs or subscriptions, stop and run the relevant product checks in `asc-submission-health`. Resume this flow only after those checks have no blocking issues and the intended product versions are prepared.
 
-If validation reports a Game Center item blocker, stop and use [references/multi-item-submissions.md](references/multi-item-submissions.md). For every other blocker, stop the release flow and use `asc-submission-health`. Do not bury unrelated remediation inside the release run.
+For Game Center items, complete only [Prepare every item](references/multi-item-submissions.md#prepare-every-item), then return to this flow. Do not assemble or submit the multi-item review submission during readiness.
+
+If app validation reports a Game Center item blocker, stop and use that preparation section. For every other blocker, stop the release flow and use `asc-submission-health`. Do not bury unrelated remediation inside the release run.
 
 ## Stage an existing build
 

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: asc-release-flow
-description: Orchestrate App Store releases with asc, including staging a version, uploading or building an artifact, publishing, and submitting for review. Use when the user wants to prepare or execute a release; route readiness failures, stuck submissions, cancellation, and retry decisions to asc-submission-health.
+description: Orchestrate App Store releases with asc, including staging a version, uploading or building an artifact, publishing, and submitting for review. Use when the user wants to prepare or execute a release. Keep Game Center item preparation in this skill; route other readiness failures, stuck submissions, cancellation, and retry decisions to asc-submission-health.
 ---
 
 # App Store release orchestration
 
-Use this skill to carry a release from an approved plan to App Store review. Keep blocker diagnosis and review recovery in `asc-submission-health`.
+Use this skill to carry a release from an approved plan to App Store review. Keep Game Center item preparation here; keep other blocker diagnosis and review recovery in `asc-submission-health`.
 
 ## Ownership boundary
 
@@ -16,7 +16,7 @@ This skill owns:
 - submitting a prepared version;
 - assembling a multi-item review submission.
 
-Stop and use `asc-submission-health` when validation reports blockers, a submission is stuck, or the user wants to cancel or retry review.
+Use [references/multi-item-submissions.md](references/multi-item-submissions.md) for Game Center item preparation or attachment blockers. Stop and use `asc-submission-health` for other validation blockers, a stuck submission, cancellation, or retry decisions.
 
 ## Preconditions
 
@@ -53,7 +53,7 @@ asc validate --app "APP_ID" --version "1.2.3" --platform IOS --strict --output t
 
 If the app includes digital goods, use `asc-submission-health` to verify those resources before returning to this flow. If it includes Game Center items, continue with [references/multi-item-submissions.md](references/multi-item-submissions.md), which owns their preparation and attachment.
 
-If validation reports a blocker, stop the release flow and use `asc-submission-health`. Do not bury remediation inside the release run.
+If validation reports a Game Center item blocker, stop and use [references/multi-item-submissions.md](references/multi-item-submissions.md). For every other blocker, stop the release flow and use `asc-submission-health`. Do not bury unrelated remediation inside the release run.
 
 ## Stage an existing build
 

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -1,58 +1,65 @@
 ---
 name: asc-release-flow
-description: Determine whether an app is ready to submit, then drive the current App Store release flow with asc, including validation, staging, review submission, first-time availability, versioned subscriptions and IAPs, Game Center, and App Privacy checks.
+description: Orchestrate App Store releases with asc, including staging a version, uploading or building an artifact, publishing, and submitting for review. Use when the user wants to prepare or execute a release; route readiness failures, stuck submissions, cancellation, and retry decisions to asc-submission-health.
 ---
 
-# Release flow (readiness-first)
+# App Store release orchestration
 
-Use this skill when the question is "Can my app be submitted now?" or when the user wants to prepare and submit an App Store version with the current `asc` command surface.
+Use this skill to carry a release from an approved plan to App Store review. Keep blocker diagnosis and review recovery in `asc-submission-health`.
+
+## Ownership boundary
+
+This skill owns:
+
+- staging metadata and attaching a build;
+- publishing an IPA or building locally;
+- submitting a prepared version;
+- assembling a multi-item review submission.
+
+Stop and use `asc-submission-health` when validation reports blockers, a submission is stuck, or the user wants to cancel or retry review.
 
 ## Preconditions
 
-- Resolve `APP_ID`, version string, `VERSION_ID` when needed, and `BUILD_ID` up front.
-- Ensure auth is configured with `asc auth login` or `ASC_*` environment variables.
-- Have canonical metadata in `./metadata` when using metadata-driven staging.
-- Treat `asc web ...` commands as optional web-session fallbacks for flows not covered by the public API.
+- Resolve `APP_ID`, the version string, `VERSION_ID` when needed, and `BUILD_ID` when a build already exists.
+- Configure auth with `asc auth login` or `ASC_*` environment variables.
+- Confirm the intended platform. Use `IOS` unless the app targets another platform.
+- Keep canonical metadata in `./metadata` when the workflow applies metadata.
+- Require a dry run before a mutating high-level command, then require `--confirm` for submission.
 
-## Answer order
+## Choose the release lane
 
-1. Say whether the app is ready right now.
-2. Name the blocking issues.
-3. Separate public-API fixes from web-session or manual fixes.
-4. Give the next exact command to run.
+| Intent | Command |
+| --- | --- |
+| Prepare metadata and attach an existing build without submitting | `asc release stage` |
+| Submit an already prepared version | `asc review submit` |
+| Upload an IPA or build locally, then optionally submit | `asc publish appstore` |
+| Submit the app version with IAP, subscription, or Game Center version items | lower-level `asc review` submission commands |
 
-Blockers usually fall into:
+Do not mix lanes after one has already created a review submission. Inspect the existing submission first and continue through the matching lower-level commands.
 
-- API-fixable: build validity, metadata, screenshots, review details, content rights, encryption, version/build attachment, IAP readiness, Game Center version and review-submission items.
-- Web-session-fixable: first-review subscription attachment and App Privacy publish state.
-- Manual fallback: first-time IAP selection on the app-version page when no CLI attach flow exists, or any flow the user does not want to run through web-session commands.
+## Run the readiness gate
 
-## Canonical current path
-
-### 1. Readiness check
-
-Use `asc validate`; the old submit-preflight shortcut is not part of the current CLI.
+Validate before any submission:
 
 ```bash
 asc validate --app "APP_ID" --version "1.2.3" --platform IOS --output table
 ```
 
-Use strict mode when warnings should block automation:
+Use strict mode when warnings must stop automation:
 
 ```bash
 asc validate --app "APP_ID" --version "1.2.3" --platform IOS --strict --output table
 ```
 
-For apps selling digital goods, run the product readiness checks too:
+If the app includes digital goods, use `asc-submission-health` to verify those resources before returning to this flow. If it includes Game Center items, continue with [references/multi-item-submissions.md](references/multi-item-submissions.md), which owns their preparation and attachment.
 
-```bash
-asc validate iap --app "APP_ID" --output table
-asc validate subscriptions --app "APP_ID" --output table
-```
+If validation reports a blocker, stop the release flow and use `asc-submission-health`. Do not bury remediation inside the release run.
 
-### 2. Stage without submitting
+## Stage an existing build
 
-Use `asc release stage` when the user wants to prepare the version, apply/copy metadata, attach the build, and validate, while stopping before review submission.
+Use `asc release stage` to ensure the version, apply or copy metadata, attach the selected build, and run validation without creating a review submission.
+
+Preview metadata-driven staging:
 
 ```bash
 asc release stage \
@@ -64,7 +71,7 @@ asc release stage \
   --output table
 ```
 
-Apply the staging mutations after the plan looks correct:
+Apply the reviewed plan:
 
 ```bash
 asc release stage \
@@ -75,409 +82,70 @@ asc release stage \
   --confirm
 ```
 
-Use `--copy-metadata-from "1.2.2"` instead of `--metadata-dir` when carrying metadata forward from an existing version.
+Use `--copy-metadata-from "1.2.2"` instead of `--metadata-dir` when carrying localization metadata forward. Add `--strict-validate` when warnings should fail the stage.
 
-### 3. Submit an already prepared version
+## Submit a prepared version
 
-Use `asc review submit` for explicit App Store review submission. It wraps build attachment plus review submission creation.
+Use `asc review submit` after metadata, review details, availability, build processing, and product readiness are already resolved.
 
 ```bash
 asc review submit --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --dry-run --output table
 asc review submit --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --confirm
 ```
 
-Use `--version-id "VERSION_ID"` instead of `--version` when you already resolved the exact version ID.
+Use `--version-id "VERSION_ID"` instead of `--version` when the exact version ID is known. `--build` may be omitted only when the intended build is already attached and verified.
 
-### 4. One-command upload and submit
+## Upload or build, then publish
 
-Use `asc publish appstore` when upload/build/local-build and submission should be one high-level flow.
+Use `asc publish appstore` when the release starts from an IPA or a local Xcode project/workspace.
 
-```bash
-asc publish appstore --app "APP_ID" --ipa "./App.ipa" --version "1.2.3" --submit --dry-run --output table
-asc publish appstore --app "APP_ID" --ipa "./App.ipa" --version "1.2.3" --submit --confirm
-```
-
-Add `--wait` when the command should wait for build processing before attaching/submitting.
-
-### 5. Monitor and cancel
+Preview an IPA upload and submission:
 
 ```bash
-asc status --app "APP_ID"
-asc submit status --version-id "VERSION_ID"
-asc submit status --id "SUBMISSION_ID"
-asc submit cancel --id "SUBMISSION_ID" --confirm
-```
-
-## First-time submission blockers
-
-### Initial app availability does not exist
-
-Symptoms:
-
-- `asc pricing availability view --app "APP_ID"` reports no availability.
-- `asc pricing availability edit ...` cannot update because there is no existing availability record.
-
-Check:
-
-```bash
-asc pricing availability view --app "APP_ID"
-```
-
-Bootstrap the first availability record through the public API:
-
-```bash
-asc pricing availability create \
+asc publish appstore \
   --app "APP_ID" \
-  --territory "USA,GBR" \
-  --available true \
-  --available-in-new-territories true
+  --ipa "./App.ipa" \
+  --version "1.2.3" \
+  --submit \
+  --dry-run \
+  --output table
 ```
 
-After bootstrap, use the public API for ongoing changes:
+Run it after reviewing the plan:
 
 ```bash
-asc pricing availability edit \
+asc publish appstore \
   --app "APP_ID" \
-  --territory "USA,GBR" \
-  --available true \
-  --available-in-new-territories true
-```
-
-### Subscriptions are ready but not attached to first review
-
-Check subscription readiness first:
-
-```bash
-asc validate subscriptions --app "APP_ID" --output table
-```
-
-If diagnostics report missing metadata, fix those prerequisites before attaching. Common misses are broad pricing coverage, review screenshots, promotional images, and app/build evidence.
-
-List first-review subscription state:
-
-```bash
-asc web review subscriptions list --app "APP_ID"
-```
-
-Attach a group for first review:
-
-```bash
-asc web review subscriptions attach-group \
-  --app "APP_ID" \
-  --group-id "GROUP_ID" \
+  --ipa "./App.ipa" \
+  --version "1.2.3" \
+  --submit \
+  --wait \
   --confirm
 ```
 
-Attach one subscription instead:
+For local-build mode, provide `--workspace` or `--project` with `--scheme` instead of `--ipa`. Use `--metadata-dir` when the publish command should apply canonical version metadata after ensuring the version.
 
-```bash
-asc web review subscriptions attach \
-  --app "APP_ID" \
-  --subscription-id "SUB_ID" \
-  --confirm
-```
+Omit `--submit` when the user wants upload and attachment only.
 
-The product-scoped `asc subscriptions review submit` shortcut is deprecated.
-Do not build new workflows around it.
+## Submit multiple review items
 
-The API 4.4.1 versioned workflow below is for a subsequent review or another
-existing review submission. It does not replace the web-session flow above for
-attaching a subscription or group to its first review. Prepare the
-version-scoped metadata and add that version—not the subscription product—to
-the existing submission:
+Read [references/multi-item-submissions.md](references/multi-item-submissions.md) when the app version must ship with versioned IAP, subscription, subscription-group, or Game Center items. Add only items the user has resolved and inspected.
 
-```bash
-asc subscriptions versions list --subscription-id "SUB_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
-```
+## Handoff after submission
 
-Branch on the number of returned versions before any write:
+Report:
 
-- Zero: create one version and capture `.data.id` as
-  `SUBSCRIPTION_VERSION_ID`.
-- One: reuse `.data[0].id` as `SUBSCRIPTION_VERSION_ID`; do not create.
-- More than one: stop and require the user to choose an explicit version ID.
+- the app, version, platform, build, and submission IDs;
+- which lane ran and whether it completed;
+- every mutation confirmed by the user;
+- the exact command to monitor the resulting submission.
 
-Run this only in the zero-result branch:
+Use `asc-submission-health` for monitoring, cancellation, rejection diagnosis, or retry decisions.
 
-```bash
-asc subscriptions versions create --subscription-id "SUB_ID" --output json
-```
+## Guardrails
 
-Resolve the intended locale before writing:
-
-```bash
-asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
-```
-
-If `en-US` is absent, create it:
-
-```bash
-asc subscriptions versions localizations create --version-id "SUBSCRIPTION_VERSION_ID" --locale "en-US" --name "Premium" --description "Premium access"
-```
-
-If the single resolved `en-US` localization exists but differs, update that
-resolved ID. If it already matches, reuse it and do nothing. Stop if locale
-resolution is ambiguous.
-
-```bash
-asc subscriptions versions localizations update --id "SUBSCRIPTION_LOC_ID" --name "Premium" --description "Premium access"
-```
-
-Resolve images before writing:
-
-```bash
-asc subscriptions versions images list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output json
-```
-
-If the intended image is already present, reuse it and do nothing. If no image
-is present, upload it:
-
-```bash
-asc subscriptions versions images upload --version-id "SUBSCRIPTION_VERSION_ID" --file "./promotional.png"
-```
-
-If a different image must be replaced, make that a separate, explicitly
-confirmed branch using its resolved ID, then upload the replacement:
-
-```bash
-asc subscriptions versions images delete --id "SUBSCRIPTION_IMAGE_ID" --confirm
-asc subscriptions versions images upload --version-id "SUBSCRIPTION_VERSION_ID" --file "./promotional.png"
-```
-
-Inspect the resolved version and children before adding the version to the
-existing review submission:
-
-```bash
-asc subscriptions versions view --id "SUBSCRIPTION_VERSION_ID" --output table
-asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
-asc subscriptions versions images primary --version-id "SUBSCRIPTION_VERSION_ID" --output table
-asc subscriptions versions images list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
-asc review items add --submission "SUBMISSION_ID" --item-type subscriptionVersions --item-id "SUBSCRIPTION_VERSION_ID"
-```
-
-Subscription group versions follow the same existing-submission model:
-
-```bash
-asc subscriptions groups versions list --group-id "GROUP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
-```
-
-Branch on the number of returned group versions before any write:
-
-- Zero: create one version and capture `.data.id` as `GROUP_VERSION_ID`.
-- One: reuse `.data[0].id` as `GROUP_VERSION_ID`; do not create.
-- More than one: stop and require the user to choose an explicit version ID.
-
-Run this only in the zero-result branch:
-
-```bash
-asc subscriptions groups versions create --group-id "GROUP_ID" --output json
-```
-
-Resolve the intended locale before writing:
-
-```bash
-asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output json
-```
-
-If `en-US` is absent, create it:
-
-```bash
-asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Premium"
-```
-
-If the single resolved `en-US` localization exists but differs, update that
-resolved ID. If it already matches, reuse it and do nothing. Stop if locale
-resolution is ambiguous.
-
-```bash
-asc subscriptions groups versions localizations update --id "GROUP_LOC_ID" --name "Premium"
-```
-
-Inspect the resolved group version and localizations before adding it to the
-existing review submission:
-
-```bash
-asc subscriptions groups versions view --version-id "GROUP_VERSION_ID" --output table
-asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
-asc review items add --submission "SUBMISSION_ID" --item-type subscriptionGroupVersions --item-id "GROUP_VERSION_ID"
-```
-
-### In-app purchases need review readiness or first-version inclusion
-
-```bash
-asc validate iap --app "APP_ID" --output table
-```
-
-Upload missing review screenshots:
-
-```bash
-asc iap review-screenshots create --iap-id "IAP_ID" --file "./review.png"
-```
-
-The product-scoped `asc iap submit` shortcut is deprecated. Use the versioned
-workflow below for new review submissions.
-
-For an API 4.4.1 IAP version, use its version ID throughout the v2 metadata,
-image, and review flow:
-
-```bash
-asc iap versions list --iap-id "IAP_ID" --state PREPARE_FOR_SUBMISSION --paginate --output json
-```
-
-Branch on the number of returned IAP versions before any write:
-
-- Zero: create one version and capture `.data.id` as `IAP_VERSION_ID`.
-- One: reuse `.data[0].id` as `IAP_VERSION_ID`; do not create.
-- More than one: stop and require the user to choose an explicit version ID.
-
-Run this only in the zero-result branch:
-
-```bash
-asc iap versions create --iap-id "IAP_ID" --output json
-```
-
-Resolve the intended locale before writing:
-
-```bash
-asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output json
-```
-
-If `en-US` is absent, create it:
-
-```bash
-asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Premium" --description "Unlock premium features"
-```
-
-If the single resolved `en-US` localization exists but differs, update that
-resolved ID. If it already matches, reuse it and do nothing. Stop if locale
-resolution is ambiguous.
-
-```bash
-asc iap versions localizations update --localization-id "IAP_LOC_ID" --name "Premium" --description "Unlock premium features"
-```
-
-Resolve images before writing:
-
-```bash
-asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output json
-```
-
-If the intended image is already present, reuse it and do nothing. If no image
-is present, create it:
-
-```bash
-asc iap versions images create --version-id "IAP_VERSION_ID" --file "./review.png"
-```
-
-If a different image must be replaced, make that a separate, explicitly
-confirmed branch using its resolved ID, then create the replacement:
-
-```bash
-asc iap versions images delete --image-id "IAP_IMAGE_ID" --confirm
-asc iap versions images create --version-id "IAP_VERSION_ID" --file "./review.png"
-```
-
-Inspect the resolved version and children before adding it to the existing
-review submission:
-
-```bash
-asc iap versions view --version-id "IAP_VERSION_ID" --output table
-asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output table
-asc iap versions image --version-id "IAP_VERSION_ID" --output table
-asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output table
-asc iap versions submit --version-id "IAP_VERSION_ID" --submission "SUBMISSION_ID" --confirm
-```
-
-For the first IAP on an app, or the first time adding a new IAP type, Apple may require selecting the IAP from the app version's "In-App Purchases and Subscriptions" section before submitting the app version. Prepare the IAP with localization, pricing, and review screenshot data first.
-
-For non-renewing IAPs that must be attached to the next app version review, the public API may reject the review item path. The CLI exposes a web-session fallback that mirrors the App Store Connect web flow:
-
-```bash
-asc web review iaps attach --app "APP_ID" --iap-id "IAP_ID" --confirm
-```
-
-Use this only for the web-only first-version selection gap, and call out that it requires an authenticated Apple web session.
-
-### Game Center needs app-version and review-submission items
-
-```bash
-asc game-center app-versions list --app "APP_ID"
-asc game-center app-versions create --app-store-version-id "VERSION_ID"
-```
-
-If Game Center component versions must ship with the app version, use the explicit review-submission API so all items can be added before submission:
-
-```bash
-asc review submissions-create --app "APP_ID" --platform IOS
-asc review items add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
-asc review items add --submission "SUBMISSION_ID" --item-type gameCenterLeaderboardVersions --item-id "GC_LEADERBOARD_VERSION_ID"
-asc review items add --submission "SUBMISSION_ID" --item-type inAppPurchaseVersions --item-id "IAP_VERSION_ID"
-asc review items add --submission "SUBMISSION_ID" --item-type subscriptionVersions --item-id "SUBSCRIPTION_VERSION_ID"
-asc review items add --submission "SUBMISSION_ID" --item-type subscriptionGroupVersions --item-id "GROUP_VERSION_ID"
-asc review submissions-submit --id "SUBMISSION_ID" --confirm
-```
-
-`asc review items add` also supports `gameCenterAchievementVersions`, `gameCenterActivityVersions`, `gameCenterChallengeVersions`, and `gameCenterLeaderboardSetVersions`.
-
-### App Privacy is still unpublished
-
-The public API can surface privacy advisories, but it cannot fully verify App Privacy publish state.
-
-```bash
-asc web privacy pull --app "APP_ID" --out "./privacy.json"
-asc web privacy plan --app "APP_ID" --file "./privacy.json"
-asc web privacy apply --app "APP_ID" --file "./privacy.json"
-asc web privacy publish --app "APP_ID" --confirm
-```
-
-If the user avoids web-session commands, confirm App Privacy manually in App Store Connect:
-
-```text
-https://appstoreconnect.apple.com/apps/APP_ID/appPrivacy
-```
-
-### Review details are incomplete
-
-```bash
-asc review details-for-version --version-id "VERSION_ID"
-```
-
-Create or update details:
-
-```bash
-asc review details-create \
-  --version-id "VERSION_ID" \
-  --contact-first-name "Dev" \
-  --contact-last-name "Support" \
-  --contact-email "dev@example.com" \
-  --contact-phone "+1 555 0100" \
-  --notes "Explain the reviewer access path here."
-
-asc review details-update \
-  --id "DETAIL_ID" \
-  --notes "Updated reviewer instructions."
-```
-
-Only set demo-account fields when App Review truly needs demo credentials.
-
-## Ready checklist
-
-An app is effectively ready when:
-
-- `asc validate --app "APP_ID" --version "VERSION" --platform IOS` has no blocking issues.
-- `asc release stage --dry-run` produces the expected plan, or `asc release stage --confirm` has successfully prepared the target version.
-- The build is `VALID` and attached to the target version.
-- Metadata, screenshots, app info, content rights, encryption, age rating, and review details are complete.
-- App availability exists.
-- Digital goods have localization, pricing, review screenshots, and any first-review attachments or manual selections handled.
-- Game Center app-version and component review items are included when needed.
-- App Privacy is confirmed or published.
-
-## Notes
-
-- Do not use the legacy submit-preflight, submit-create, or release-run shortcuts; they are not part of the current CLI.
-- Use `asc validate` for readiness.
-- Use `asc release stage` for pre-submit preparation.
-- Use `asc review submit` for explicit App Store review submission.
-- Use `asc publish appstore --submit --confirm` for high-level upload plus submission.
-- Use `asc status` and `asc submit status` after submission.
+- Do not use removed `submit-preflight`, `submit-create`, or `release-run` shortcuts.
+- Do not add `--confirm` until the dry-run plan matches the requested release.
+- Do not create a second review submission when one already exists for the version.
+- Do not turn a validation failure into a partial release; stop at the failing gate.
+- Keep data on stdout and diagnostics on stderr when wrapping commands in automation.

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -39,6 +39,8 @@ Do not mix lanes after one has already created a review submission. Inspect the 
 
 ## Run the readiness gate
 
+Apply this gate to a version that already has the intended build attached. For the staging lane, first complete [Stage an existing build](#stage-an-existing-build); `asc release stage` attaches the build and runs validation, after which this gate can be evaluated. Do not route an expected pre-staging "build not attached" result to `asc-submission-health`.
+
 Validate before any submission:
 
 ```bash
@@ -55,7 +57,7 @@ Digital goods are a hard gate. If the release includes IAPs or subscriptions, st
 
 For Game Center items, complete only [Prepare every item](references/multi-item-submissions.md#prepare-every-item), then return to this flow. Do not assemble or submit the multi-item review submission during readiness.
 
-If app validation reports a Game Center item blocker, stop and use that preparation section. For every other blocker, stop the release flow and use `asc-submission-health`. Do not bury unrelated remediation inside the release run.
+If app validation reports a Game Center item blocker, stop and use that preparation section. If the only blocker is an unattached build in the staging lane, continue to the staging section. For every other blocker, stop the release flow and use `asc-submission-health`. Do not bury unrelated remediation inside the release run.
 
 ## Stage an existing build
 

--- a/skills/asc-release-flow/references/multi-item-submissions.md
+++ b/skills/asc-release-flow/references/multi-item-submissions.md
@@ -2,6 +2,12 @@
 
 Read this reference when one review submission must contain the app version plus versioned digital goods, Game Center components, or both.
 
+Follow only the section for the current phase:
+
+- During readiness, complete **Prepare every item**, then return to the main release flow.
+- Enter **Assemble the submission** only after the app version is staged and the multi-item lane is selected.
+- Enter **Submit** only after inspecting the assembled draft and obtaining confirmation.
+
 ## Prepare every item
 
 - Resolve the exact `VERSION_ID` and each product or component version ID.
@@ -16,6 +22,8 @@ asc game-center app-versions create --app-store-version-id "VERSION_ID" --output
 Create only when the intended Game Center app version is absent.
 
 ## Assemble the submission
+
+Do not create a review submission from the readiness gate. Start this phase only after the app version and build are staged and the user has selected the multi-item lane.
 
 Create one review submission and capture its ID:
 

--- a/skills/asc-release-flow/references/multi-item-submissions.md
+++ b/skills/asc-release-flow/references/multi-item-submissions.md
@@ -50,7 +50,13 @@ asc review submissions-create --app "APP_ID" --platform IOS --output json
 
 Use the reused or newly created ID as `SUBMISSION_ID` below. If neither branch assigned one, do not continue.
 
-Add the app version first, followed by the resolved product and Game Center version items:
+List the draft's current items before attaching anything:
+
+```bash
+asc review items list --submission "SUBMISSION_ID" --paginate --output json
+```
+
+Compare each intended item type and resource ID with the returned relationships. Skip exact matches already attached to this draft. Add only missing items, with the app version first, followed by the resolved product and Game Center version items:
 
 ```bash
 asc review items add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"

--- a/skills/asc-release-flow/references/multi-item-submissions.md
+++ b/skills/asc-release-flow/references/multi-item-submissions.md
@@ -38,7 +38,7 @@ asc review submissions-list \
 
 Branch before writing:
 
-- If `asc-submission-health` or the caller handed off a `SUBMISSION_ID`, inspect it with `asc review submissions-get --id "SUBMISSION_ID" --include "items,appStoreVersionForReview" --output json`. Reuse it only when it is the intended `READY_FOR_REVIEW` draft. If it fails that check, stop; do not create another submission or add items.
+- If `asc-submission-health` or the caller handed off a `SUBMISSION_ID`, inspect it with `asc review submissions-get --id "SUBMISSION_ID" --include "items,appStoreVersionForReview" --output json`. Reuse it only when it is the intended `READY_FOR_REVIEW` draft. If it fails that check, stop and return the mismatch to `asc-submission-health` for diagnosis; do not create another submission or add items.
 - With no handed-off ID, if exactly one `READY_FOR_REVIEW` draft matches the intended release, capture and reuse its ID.
 - With no handed-off ID, if no matching draft or active submission exists for the intended version or review items, create one and capture its ID:
 

--- a/skills/asc-release-flow/references/multi-item-submissions.md
+++ b/skills/asc-release-flow/references/multi-item-submissions.md
@@ -25,11 +25,30 @@ Create only when the intended Game Center app version is absent.
 
 Do not create a review submission from the readiness gate. Start this phase only after the app version and build are staged and the user has selected the multi-item lane.
 
-Create one review submission and capture its ID:
+Inspect existing submissions before creating one:
+
+```bash
+asc review submissions-list \
+  --app "APP_ID" \
+  --platform IOS \
+  --include "items,appStoreVersionForReview" \
+  --paginate \
+  --output json
+```
+
+Branch before writing:
+
+- If `asc-submission-health` or the caller handed off a `SUBMISSION_ID`, inspect it with `asc review submissions-get --id "SUBMISSION_ID" --include "items,appStoreVersionForReview" --output json`. Reuse it only when it is the intended `READY_FOR_REVIEW` draft.
+- If exactly one `READY_FOR_REVIEW` draft matches the intended release, capture and reuse its ID.
+- If no matching draft or active submission exists, create one and capture its ID:
 
 ```bash
 asc review submissions-create --app "APP_ID" --platform IOS --output json
 ```
+
+- If more than one draft could match, or the intended version already has a submission in another active state, stop and diagnose through `asc-submission-health`. Do not create a second submission.
+
+Use the reused or newly created ID as `SUBMISSION_ID` below.
 
 Add the app version first, followed by the resolved product and Game Center version items:
 

--- a/skills/asc-release-flow/references/multi-item-submissions.md
+++ b/skills/asc-release-flow/references/multi-item-submissions.md
@@ -38,17 +38,17 @@ asc review submissions-list \
 
 Branch before writing:
 
-- If `asc-submission-health` or the caller handed off a `SUBMISSION_ID`, inspect it with `asc review submissions-get --id "SUBMISSION_ID" --include "items,appStoreVersionForReview" --output json`. Reuse it only when it is the intended `READY_FOR_REVIEW` draft.
-- If exactly one `READY_FOR_REVIEW` draft matches the intended release, capture and reuse its ID.
-- If no matching draft or active submission exists, create one and capture its ID:
+- If `asc-submission-health` or the caller handed off a `SUBMISSION_ID`, inspect it with `asc review submissions-get --id "SUBMISSION_ID" --include "items,appStoreVersionForReview" --output json`. Reuse it only when it is the intended `READY_FOR_REVIEW` draft. If it fails that check, stop; do not create another submission or add items.
+- With no handed-off ID, if exactly one `READY_FOR_REVIEW` draft matches the intended release, capture and reuse its ID.
+- With no handed-off ID, if no matching draft or active submission exists for the intended version or review items, create one and capture its ID:
 
 ```bash
 asc review submissions-create --app "APP_ID" --platform IOS --output json
 ```
 
-- If more than one draft could match, or the intended version already has a submission in another active state, stop and diagnose through `asc-submission-health`. Do not create a second submission.
+- Otherwise—when drafts are ambiguous or the intended version or review items belong to another active submission—stop and diagnose through `asc-submission-health`. Do not create a second submission.
 
-Use the reused or newly created ID as `SUBMISSION_ID` below.
+Use the reused or newly created ID as `SUBMISSION_ID` below. If neither branch assigned one, do not continue.
 
 Add the app version first, followed by the resolved product and Game Center version items:
 

--- a/skills/asc-release-flow/references/multi-item-submissions.md
+++ b/skills/asc-release-flow/references/multi-item-submissions.md
@@ -1,0 +1,55 @@
+# Multi-item review submissions
+
+Read this reference when one review submission must contain the app version plus versioned digital goods, Game Center components, or both.
+
+## Prepare every item
+
+- Resolve the exact `VERSION_ID` and each product or component version ID.
+- Use `asc-submission-health` to repair missing IAP, subscription, or subscription-group versions.
+- Confirm the Game Center app version exists:
+
+```bash
+asc game-center app-versions list --app "APP_ID" --output table
+asc game-center app-versions create --app-store-version-id "VERSION_ID" --output json
+```
+
+Create only when the intended Game Center app version is absent.
+
+## Assemble the submission
+
+Create one review submission and capture its ID:
+
+```bash
+asc review submissions-create --app "APP_ID" --platform IOS --output json
+```
+
+Add the app version first, followed by the resolved product and Game Center version items:
+
+```bash
+asc review items add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type inAppPurchaseVersions --item-id "IAP_VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type subscriptionVersions --item-id "SUBSCRIPTION_VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type subscriptionGroupVersions --item-id "GROUP_VERSION_ID"
+asc review items add --submission "SUBMISSION_ID" --item-type gameCenterLeaderboardVersions --item-id "GC_LEADERBOARD_VERSION_ID"
+```
+
+Supported Game Center item types also include:
+
+- `gameCenterAchievementVersions`
+- `gameCenterActivityVersions`
+- `gameCenterChallengeVersions`
+- `gameCenterLeaderboardSetVersions`
+
+Add only types required for this release. Do not submit placeholder or unresolved IDs.
+
+## Submit
+
+Inspect the assembled submission before the final mutation, then require confirmation:
+
+```bash
+asc review submissions-get --id "SUBMISSION_ID" --include items --output table
+asc review items list --submission "SUBMISSION_ID" --paginate --output table
+asc review submissions-submit --id "SUBMISSION_ID" --confirm
+```
+
+If inspection shows an existing active or completed submission instead of the draft being assembled, stop and diagnose through `asc-submission-health` rather than creating another submission.

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -123,12 +123,14 @@ asc review history --app "APP_ID" --version "1.2.3" --paginate --output table
 Resolve the exact active submission before cancelling. Preview status first, then require confirmation:
 
 ```bash
+asc submit status --id "SUBMISSION_ID" --output table
 asc submit cancel --id "SUBMISSION_ID" --confirm
 ```
 
 When resolving by version, include the app for the modern review-submission lookup:
 
 ```bash
+asc submit status --version-id "VERSION_ID" --output table
 asc submit cancel --version-id "VERSION_ID" --app "APP_ID" --confirm
 ```
 

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -74,6 +74,8 @@ Read [references/digital-goods.md](references/digital-goods.md) only when IAP or
 
 Read [references/app-privacy.md](references/app-privacy.md) only when validation reports an App Privacy advisory or the publish state cannot be confirmed through the public API.
 
+When validation reports a Game Center component or version blocker, hand it to `asc-release-flow` and request the multi-item reference's **Prepare every item** section. Do not route Game Center through general readiness or digital-goods repairs.
+
 Use the web-session commands only for a gap the public API cannot cover, and say that an authenticated Apple web session is required. Keep a manual App Store Connect fallback when the user declines web-session automation.
 
 ## Decide whether the version is healthy
@@ -156,6 +158,7 @@ There is no dedicated retry command. Use this sequence:
 | Export compliance must be approved | build info and encryption declaration | readiness repairs |
 | Multiple app infos found | `asc apps info list --app "APP_ID"` | resolve exact app-info ID |
 | IAP or subscription is not ready | product validator | digital-goods reference |
+| Game Center component or version is not ready | `asc validate` diagnostic | `asc-release-flow` multi-item preparation section |
 | App Privacy publish state is unclear | validation advisory | App Privacy reference |
 | Review appears stuck | review status plus history | monitor; cancel only with evidence and approval |
 

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -150,7 +150,7 @@ There is no dedicated retry command. Use this sequence:
 2. Repair the proven blockers.
 3. Re-run `asc validate` and the relevant product validators.
 4. Confirm no active submission already owns the version or review items.
-5. Hand the healthy version to `asc-release-flow` for the new submission.
+5. Hand the healthy version and any preserved `SUBMISSION_ID` to `asc-release-flow` for submission execution. Reuse an inspected `READY_FOR_REVIEW` draft; create a submission only when no matching draft or active submission exists.
 
 ## Common failure routing
 

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -1,289 +1,169 @@
 ---
 name: asc-submission-health
-description: Validate App Store submission readiness, submit prepared versions, and monitor review status with current asc commands. Use when shipping or troubleshooting review submissions.
+description: Diagnose App Store submission blockers and operate review health with asc, including readiness validation, repair routing, status monitoring, cancellation, and retry decisions. Use when validation fails, a version is not in a valid state, review status is unclear or stuck, or a failed submission must be repaired and retried. For staging, upload, publication, and submission execution, use asc-release-flow.
 ---
 
-# asc submission health
+# App Store submission health
 
-Use this skill to reduce review submission failures and monitor review state. The current readiness command is `asc validate`; legacy submit-preflight and submit-create shortcuts must not be used.
+Use this skill to explain why a release cannot proceed and to manage an existing review submission. Hand healthy release execution back to `asc-release-flow`.
 
-## Preconditions
+## Ownership boundary
 
-- Auth configured and app/version/build IDs resolved.
-- Build processing completed or the command uses a high-level flow with `--wait`.
-- Metadata, app info, screenshots, review details, content rights, encryption, pricing, and availability are expected to be complete.
+This skill owns:
 
-## Pre-submission checklist
+- readiness validation and blocker diagnosis;
+- public-API, web-session, and manual repair routing;
+- review status and history;
+- cancellation and retry decisions.
 
-### 1. Verify build status
+Do not stage, upload, publish, or submit a healthy release from this skill.
 
-```bash
-asc builds info --build-id "BUILD_ID"
-```
+## Answer order
 
-Check:
+1. State whether the version is ready, blocked, or already under review.
+2. Name each blocker and the evidence that proves it.
+3. Separate public-API repairs from web-session and manual work.
+4. Give one next command. Do not dump the entire repair catalog.
 
-- `processingState` is `VALID`.
-- encryption fields are understood before submission.
+## Establish the target
 
-### 2. Run canonical readiness validation
+- Resolve `APP_ID`, the version string or `VERSION_ID`, `BUILD_ID`, platform, and any known `SUBMISSION_ID`.
+- Configure auth with `asc auth login` or `ASC_*` environment variables.
+- Use `ASC_BYPASS_KEYCHAIN=1` only for repository tests and isolated verification, not normal user sessions.
+- Prefer IDs once the target is resolved; stop when app, version, or product resolution is ambiguous.
+
+## Diagnose readiness
+
+Run the canonical readiness report first:
 
 ```bash
 asc validate --app "APP_ID" --version "1.2.3" --platform IOS --output table
 ```
 
-Use strict mode when warnings should fail automation:
+Use `--version-id "VERSION_ID"` when known. Add `--strict` when warnings must fail automation.
+
+Ask the review-specific doctor for an ordered explanation:
 
 ```bash
-asc validate --app "APP_ID" --version "1.2.3" --platform IOS --strict --output table
+asc review doctor --app "APP_ID" --version "1.2.3" --platform IOS --output table
 ```
 
-If you already have the exact version ID:
+Collect direct evidence when the report points at the build or version:
 
 ```bash
-asc validate --app "APP_ID" --version-id "VERSION_ID" --platform IOS --output table
+asc builds info --build-id "BUILD_ID" --output table
+asc versions view --version-id "VERSION_ID" --include-build --include-submission --output table
 ```
 
-### 3. Encryption compliance
-
-If the build uses non-exempt encryption:
-
-```bash
-asc encryption declarations list --app "APP_ID"
-
-asc encryption declarations create \
-  --app "APP_ID" \
-  --app-description "Uses standard HTTPS/TLS" \
-  --contains-proprietary-cryptography=false \
-  --contains-third-party-cryptography=true \
-  --available-on-french-store=true
-
-asc encryption declarations assign-builds \
-  --id "DECLARATION_ID" \
-  --build "BUILD_ID"
-```
-
-If the app truly uses only exempt transport encryption, prefer updating the local plist and rebuilding:
-
-```bash
-asc encryption declarations exempt-declare --plist "./Info.plist"
-```
-
-### 4. Content rights declaration
-
-```bash
-asc apps content-rights view --app "APP_ID"
-asc apps content-rights edit --app "APP_ID" --uses-third-party-content=false
-```
-
-### 5. Age rating declaration
-
-Inspect the current declaration before editing it:
-
-```bash
-asc age-rating view --app "APP_ID" --output table
-```
-
-API 4.4.1 adds the `socialMedia` and `socialMediaAgeRestricted` declarations;
-the other age-rating declarations predate this schema. Set the new values only
-when they accurately describe the app:
-
-```bash
-asc age-rating edit --app "APP_ID" --social-media false --social-media-age-restricted false
-```
-
-Apple requires `userGeneratedContent=true` before `socialMedia` can be true.
-It also requires both `ageAssurance=true` and `socialMedia=true` before
-`socialMediaAgeRestricted` can be true. Inspect the current declaration before
-a partial edit, or set every prerequisite explicitly in the same command.
-
-Prefer `--age-rating-override-v2` when an override is required; the original
-`--age-rating-override` flag is deprecated.
-
-### 6. Version metadata and localizations
-
-```bash
-asc versions view --version-id "VERSION_ID" --include-build --include-submission
-asc localizations list --version "VERSION_ID" --output table
-```
-
-For canonical metadata repair:
-
-```bash
-asc metadata pull --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
-asc metadata validate --dir "./metadata" --output table
-asc metadata push --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata" --dry-run --output table
-asc metadata push --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
-```
-
-### 7. App info localizations and privacy policy
-
-```bash
-asc apps info list --app "APP_ID" --output table
-asc localizations list --app "APP_ID" --type app-info --app-info "APP_INFO_ID" --output table
-```
-
-For subscription or IAP apps, make sure privacy policy URL is populated:
-
-```bash
-asc app-setup info set --app "APP_ID" --primary-locale "en-US" --privacy-policy-url "https://example.com/privacy"
-```
-
-### 8. Screenshots
-
-```bash
-asc screenshots list --version-localization "LOC_ID" --output table
-asc screenshots sizes --output table
-asc screenshots validate --path "./screenshots" --device-type "IPHONE_65" --output table
-```
-
-### 9. Digital goods readiness
+For digital goods, run only the relevant product validator:
 
 ```bash
 asc validate iap --app "APP_ID" --output table
 asc validate subscriptions --app "APP_ID" --output table
 ```
 
-Use JSON when you need exact diagnostics:
+Treat the ordered remediation plan from `asc validate` as the repair queue. Fix and verify one class of blocker before moving to the next.
+
+## Route repairs
+
+Use public API commands when the blocker is build processing, metadata, screenshots, review details, encryption, content rights, age rating, availability, or version-scoped product metadata.
+
+Read [references/readiness-repairs.md](references/readiness-repairs.md) when diagnostics identify one of those common blockers or a first-release availability gap.
+
+Read [references/digital-goods.md](references/digital-goods.md) only when IAP or subscription validation fails, Apple requires first-review attachment, or a versioned product must join an existing review submission.
+
+Read [references/app-privacy.md](references/app-privacy.md) only when validation reports an App Privacy advisory or the publish state cannot be confirmed through the public API.
+
+Use the web-session commands only for a gap the public API cannot cover, and say that an authenticated Apple web session is required. Keep a manual App Store Connect fallback when the user declines web-session automation.
+
+## Decide whether the version is healthy
+
+A version is ready to return to `asc-release-flow` when:
+
+- `asc validate` has no blocking issues;
+- the attached build is `VALID`;
+- metadata, screenshots, app info, review details, content rights, encryption, age rating, pricing, and availability are resolved;
+- required digital-goods versions are prepared;
+- any Game Center version items have been checked through `asc-release-flow`'s multi-item submission reference;
+- App Privacy is confirmed or published.
+
+Do not call a version ready merely because one validator exits successfully. Report any warning that still needs a web-session or manual check.
+
+## Monitor review
+
+Use app-scoped status when the submission ID is unknown:
 
 ```bash
-asc validate subscriptions --app "APP_ID" --output json --pretty
+asc review status --app "APP_ID" --version "1.2.3" --platform IOS --output table
 ```
 
-When the product uses API 4.4.1 version-scoped metadata, inspect the exact
-version resources that will be submitted:
+Use exact submission or version IDs when available:
 
 ```bash
-asc iap versions list --iap-id "IAP_ID" --paginate --output table
-asc iap versions view --version-id "IAP_VERSION_ID" --output table
-asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output table
-asc iap versions image --version-id "IAP_VERSION_ID" --output table
-asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output table
-asc subscriptions versions list --subscription-id "SUB_ID" --paginate --output table
-asc subscriptions versions view --id "SUBSCRIPTION_VERSION_ID" --output table
-asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
-asc subscriptions versions images primary --version-id "SUBSCRIPTION_VERSION_ID" --output table
-asc subscriptions versions images list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
-asc subscriptions groups versions list --group-id "GROUP_ID" --paginate --output table
-asc subscriptions groups versions view --version-id "GROUP_VERSION_ID" --output table
-asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
+asc submit status --id "SUBMISSION_ID" --output table
+asc submit status --version-id "VERSION_ID" --output table
 ```
 
-Capture each version `.data.id` from its create response before resolving or
-mutating these children.
-
-### 10. App Privacy advisory
-
-The public API cannot fully verify App Privacy publish state. If validation reports an advisory, use the web-session flow or confirm manually.
+Use the release dashboard for surrounding build and review signals:
 
 ```bash
-asc web privacy pull --app "APP_ID" --out "./privacy.json"
-asc web privacy plan --app "APP_ID" --file "./privacy.json"
-asc web privacy apply --app "APP_ID" --file "./privacy.json"
-asc web privacy publish --app "APP_ID" --confirm
+asc status --app "APP_ID" --include builds,appstore,submission,review --output table
 ```
 
-Manual fallback:
-
-```text
-https://appstoreconnect.apple.com/apps/APP_ID/appPrivacy
-```
-
-## Submit
-
-### Submit a prepared version
-
-Use `asc review submit` for explicit App Store review submission:
+Use history to distinguish a current stall from earlier rejected or completed submissions:
 
 ```bash
-asc review submit --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --dry-run --output table
-asc review submit --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --confirm
+asc review history --app "APP_ID" --version "1.2.3" --paginate --output table
 ```
 
-Use `--version-id "VERSION_ID"` when you have already resolved the version.
+## Cancel an unhealthy submission
 
-### Upload and submit in one flow
-
-```bash
-asc publish appstore --app "APP_ID" --ipa "./App.ipa" --version "1.2.3" --submit --dry-run --output table
-asc publish appstore --app "APP_ID" --ipa "./App.ipa" --version "1.2.3" --submit --confirm
-```
-
-Add `--wait` when the command should wait for build processing.
-
-### Multi-item review submissions
-
-Use the lower-level review-submission API when the submission needs multiple review items, such as Game Center component versions:
-
-```bash
-asc review submissions-create --app "APP_ID" --platform IOS
-asc review items add --submission "SUBMISSION_ID" --item-type appStoreVersions --item-id "VERSION_ID"
-asc review items add --submission "SUBMISSION_ID" --item-type gameCenterChallengeVersions --item-id "GC_CHALLENGE_VERSION_ID"
-asc review items add --submission "SUBMISSION_ID" --item-type inAppPurchaseVersions --item-id "IAP_VERSION_ID"
-asc review items add --submission "SUBMISSION_ID" --item-type subscriptionVersions --item-id "SUBSCRIPTION_VERSION_ID"
-asc review items add --submission "SUBMISSION_ID" --item-type subscriptionGroupVersions --item-id "GROUP_VERSION_ID"
-asc review submissions-submit --id "SUBMISSION_ID" --confirm
-```
-
-For non-renewing IAPs that Apple requires to be selected with the next app version, the public API can reject both direct review items and standalone IAP submission. After validating IAP readiness, use the web-session attachment only for that web-only gap:
-
-```bash
-asc web review iaps attach --app "APP_ID" --iap-id "IAP_ID" --confirm
-```
-
-This command requires an authenticated Apple web session and should be documented in the handoff.
-
-## Monitor
-
-```bash
-asc status --app "APP_ID"
-asc submit status --id "SUBMISSION_ID"
-asc submit status --version-id "VERSION_ID"
-asc review submissions-list --app "APP_ID" --paginate
-```
-
-## Cancel and retry
+Resolve the exact active submission before cancelling. Preview status first, then require confirmation:
 
 ```bash
 asc submit cancel --id "SUBMISSION_ID" --confirm
+```
+
+When resolving by version, include the app for the modern review-submission lookup:
+
+```bash
 asc submit cancel --version-id "VERSION_ID" --app "APP_ID" --confirm
+```
+
+The lower-level equivalent is valid when the exact review submission is already known:
+
+```bash
 asc review submissions-cancel --id "SUBMISSION_ID" --confirm
 ```
 
-Fix validation issues, then submit again with `asc review submit` or `asc publish appstore --submit --confirm`.
+Do not cancel a submission solely because review is taking longer than expected. Confirm the state and the user's intent first.
 
-## Common submission errors
+## Decide when to retry
 
-### Version is not in valid state
+There is no dedicated retry command. Use this sequence:
 
-Check:
+1. Cancel only if the active submission must be withdrawn.
+2. Repair the proven blockers.
+3. Re-run `asc validate` and the relevant product validators.
+4. Confirm no active submission already owns the version or review items.
+5. Hand the healthy version to `asc-release-flow` for the new submission.
 
-1. Build is attached and `VALID`.
-2. Encryption declaration is resolved or exempt.
-3. Content rights declaration is set.
-4. Required localizations and screenshots are present.
-5. Review details are present.
-6. Pricing and availability exist.
-7. App Privacy has been reviewed and published in App Store Connect.
+## Common failure routing
 
-### Export compliance must be approved
+| Symptom | First evidence | Repair route |
+| --- | --- | --- |
+| Version is not in a valid state | `asc validate`, `asc review doctor` | ordered readiness repairs |
+| Export compliance must be approved | build info and encryption declaration | readiness repairs |
+| Multiple app infos found | `asc apps info list --app "APP_ID"` | resolve exact app-info ID |
+| IAP or subscription is not ready | product validator | digital-goods reference |
+| App Privacy publish state is unclear | validation advisory | App Privacy reference |
+| Review appears stuck | review status plus history | monitor; cancel only with evidence and approval |
 
-Either upload export compliance documentation or rebuild with exempt encryption metadata if that accurately describes the app.
+## Guardrails
 
-### Multiple app infos found
-
-Use the exact app-info ID:
-
-```bash
-asc apps info list --app "APP_ID" --output table
-```
-
-## Notes
-
-- Do not use legacy submit-preflight or submit-create shortcuts; they are removed.
-- Use `asc validate` for readiness.
-- Use `asc review submit` for prepared-version submission.
-- Use `asc publish appstore --submit --confirm` for high-level upload plus submission.
-- App Privacy publish state is not fully verifiable through the public API.
-- Use `--output table` for human status and JSON for automation.
-- macOS submissions follow the same review flow but use `--platform MAC_OS`.
+- Do not use removed `submit-preflight` or `submit-create` shortcuts.
+- Do not submit from this skill; return healthy execution to `asc-release-flow`.
+- Do not treat web-session automation as public App Store Connect API coverage.
+- Do not retry until the earlier submission state and blocker repairs are verified.
+- Use `--output table` for human diagnosis and JSON for automation.
+- For macOS, use `--platform MAC_OS` while keeping the same health lifecycle.

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -83,7 +83,7 @@ A version is ready to return to `asc-release-flow` when:
 - `asc validate` has no blocking issues;
 - the attached build is `VALID`;
 - metadata, screenshots, app info, review details, content rights, encryption, age rating, pricing, and availability are resolved;
-- required digital-goods versions are prepared;
+- the relevant `asc validate iap` and/or `asc validate subscriptions` checks have no blocking issues, and the required digital-goods versions are prepared;
 - any Game Center version items have been checked through `asc-release-flow`'s multi-item submission reference;
 - App Privacy is confirmed or published.
 

--- a/skills/asc-submission-health/references/app-privacy.md
+++ b/skills/asc-submission-health/references/app-privacy.md
@@ -1,0 +1,47 @@
+# App Privacy publish state
+
+Read this reference only when readiness validation reports an App Privacy advisory or the public API cannot confirm the published state.
+
+The public App Store Connect API does not cover the full App Privacy workflow. Treat the following commands as authenticated web-session automation, not public-API proof.
+
+## Inspect and plan
+
+Pull the current answers into a reviewable file:
+
+```bash
+asc web privacy pull --app "APP_ID" --out "./privacy.json"
+```
+
+Review the planned change before writing:
+
+```bash
+asc web privacy plan --app "APP_ID" --file "./privacy.json"
+```
+
+Check every data type, purpose, tracking answer, and linkage answer against the app's real behavior and third-party SDKs. Do not infer privacy answers from the binary name or store copy.
+
+## Apply and publish
+
+Apply the reviewed file:
+
+```bash
+asc web privacy apply --app "APP_ID" --file "./privacy.json"
+```
+
+Publish only after the applied answers have been checked:
+
+```bash
+asc web privacy publish --app "APP_ID" --confirm
+```
+
+Keep the plan and apply steps separate. A successful apply does not prove that the answers were published.
+
+## Manual fallback
+
+If the user declines web-session automation, open the app's App Privacy page and confirm the published state manually:
+
+```text
+https://appstoreconnect.apple.com/apps/APP_ID/appPrivacy
+```
+
+Report the boundary plainly: the public API readiness report can raise an advisory, while final publish-state verification requires the web flow or a manual check.

--- a/skills/asc-submission-health/references/digital-goods.md
+++ b/skills/asc-submission-health/references/digital-goods.md
@@ -2,6 +2,8 @@
 
 Read this reference only when IAP or subscription validation fails, Apple requires a first-review attachment, or a versioned product must join an existing review submission.
 
+When work starts from an existing review draft, preserve its `SUBMISSION_ID` in the handoff to `asc-release-flow`. The release flow must inspect and reuse that draft rather than create another submission.
+
 ## Contents
 
 - [Run product validators](#run-product-validators)

--- a/skills/asc-submission-health/references/digital-goods.md
+++ b/skills/asc-submission-health/references/digital-goods.md
@@ -1,0 +1,275 @@
+# Digital-goods readiness
+
+Read this reference only when IAP or subscription validation fails, Apple requires a first-review attachment, or a versioned product must join an existing review submission.
+
+## Contents
+
+- [Run product validators](#run-product-validators)
+- [Attach subscriptions for first review](#attach-subscriptions-for-first-review)
+- [Prepare a subscription version](#prepare-a-subscription-version)
+- [Prepare a subscription-group version](#prepare-a-subscription-group-version)
+- [Prepare an IAP version](#prepare-an-iap-version)
+- [Handle first-version IAP attachment](#handle-first-version-iap-attachment)
+
+## Run product validators
+
+Start with the relevant validator:
+
+```bash
+asc validate iap --app "APP_ID" --output table
+asc validate subscriptions --app "APP_ID" --output table
+```
+
+Use JSON when automation needs the exact diagnostic payload:
+
+```bash
+asc validate subscriptions --app "APP_ID" --output json --pretty
+```
+
+Fix missing localization, pricing, availability, review screenshots, and promotional images before attaching products to review.
+
+## Attach subscriptions for first review
+
+The public API cannot perform the first-review subscription selection. Inspect the web-session state:
+
+```bash
+asc web review subscriptions list --app "APP_ID"
+```
+
+Attach the intended group:
+
+```bash
+asc web review subscriptions attach-group \
+  --app "APP_ID" \
+  --group-id "GROUP_ID" \
+  --confirm
+```
+
+Attach one subscription instead when that is the intended review unit:
+
+```bash
+asc web review subscriptions attach \
+  --app "APP_ID" \
+  --subscription-id "SUB_ID" \
+  --confirm
+```
+
+These commands require an authenticated Apple web session. If the user declines web-session automation, select the subscription manually in App Store Connect.
+
+Do not build new workflows around deprecated `asc subscriptions review submit`.
+
+## Prepare a subscription version
+
+Use this public-API flow for an existing review submission. It does not replace first-review web attachment.
+
+Resolve a `PREPARE_FOR_SUBMISSION` version:
+
+```bash
+asc subscriptions versions list \
+  --subscription-id "SUB_ID" \
+  --state PREPARE_FOR_SUBMISSION \
+  --paginate \
+  --output json
+```
+
+Branch before writing:
+
+- Zero versions: create one and capture `.data.id` as `SUBSCRIPTION_VERSION_ID`.
+- One version: reuse `.data[0].id`.
+- More than one: stop and require an explicit version ID.
+
+Create only in the zero-result branch:
+
+```bash
+asc subscriptions versions create --subscription-id "SUB_ID" --output json
+```
+
+Resolve the intended locale:
+
+```bash
+asc subscriptions versions localizations list \
+  --version-id "SUBSCRIPTION_VERSION_ID" \
+  --paginate \
+  --output json
+```
+
+Create `en-US` only when absent:
+
+```bash
+asc subscriptions versions localizations create \
+  --version-id "SUBSCRIPTION_VERSION_ID" \
+  --locale "en-US" \
+  --name "Premium" \
+  --description "Premium access"
+```
+
+Update the one resolved localization when its values differ:
+
+```bash
+asc subscriptions versions localizations update \
+  --id "SUBSCRIPTION_LOC_ID" \
+  --name "Premium" \
+  --description "Premium access"
+```
+
+Resolve images before uploading or deleting anything:
+
+```bash
+asc subscriptions versions images list \
+  --version-id "SUBSCRIPTION_VERSION_ID" \
+  --paginate \
+  --output json
+```
+
+Upload only when the intended image is absent:
+
+```bash
+asc subscriptions versions images upload \
+  --version-id "SUBSCRIPTION_VERSION_ID" \
+  --file "./promotional.png"
+```
+
+Treat replacement as a separate confirmed branch:
+
+```bash
+asc subscriptions versions images delete --id "SUBSCRIPTION_IMAGE_ID" --confirm
+asc subscriptions versions images upload --version-id "SUBSCRIPTION_VERSION_ID" --file "./promotional.png"
+```
+
+Inspect the completed version and return its ID to `asc-release-flow`:
+
+```bash
+asc subscriptions versions view --id "SUBSCRIPTION_VERSION_ID" --output table
+asc subscriptions versions localizations list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
+asc subscriptions versions images primary --version-id "SUBSCRIPTION_VERSION_ID" --output table
+asc subscriptions versions images list --version-id "SUBSCRIPTION_VERSION_ID" --paginate --output table
+```
+
+Do not add the version to a review submission from this skill. Hand `SUBSCRIPTION_VERSION_ID` to the multi-item workflow in `asc-release-flow`.
+
+## Prepare a subscription-group version
+
+Resolve the group version:
+
+```bash
+asc subscriptions groups versions list \
+  --group-id "GROUP_ID" \
+  --state PREPARE_FOR_SUBMISSION \
+  --paginate \
+  --output json
+```
+
+Branch before writing:
+
+- Zero versions: create one and capture `.data.id` as `GROUP_VERSION_ID`.
+- One version: reuse `.data[0].id`.
+- More than one: stop and require an explicit version ID.
+
+Create only in the zero-result branch:
+
+```bash
+asc subscriptions groups versions create --group-id "GROUP_ID" --output json
+```
+
+Resolve and repair the intended locale:
+
+```bash
+asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output json
+asc subscriptions groups versions localizations create --version-id "GROUP_VERSION_ID" --locale "en-US" --name "Premium"
+asc subscriptions groups versions localizations update --id "GROUP_LOC_ID" --name "Premium"
+```
+
+Run create only when the locale is absent; run update only when the single resolved locale differs.
+
+Inspect the group version and return its ID to `asc-release-flow`:
+
+```bash
+asc subscriptions groups versions view --version-id "GROUP_VERSION_ID" --output table
+asc subscriptions groups versions localizations list --version-id "GROUP_VERSION_ID" --paginate --output table
+```
+
+Do not add the version to a review submission from this skill. Hand `GROUP_VERSION_ID` to the multi-item workflow in `asc-release-flow`.
+
+## Prepare an IAP version
+
+Upload a missing legacy review screenshot when diagnostics request one:
+
+```bash
+asc iap review-screenshots create --iap-id "IAP_ID" --file "./review.png"
+```
+
+Do not build new workflows around deprecated `asc iap submit`.
+
+Resolve a version-scoped IAP:
+
+```bash
+asc iap versions list \
+  --iap-id "IAP_ID" \
+  --state PREPARE_FOR_SUBMISSION \
+  --paginate \
+  --output json
+```
+
+Branch before writing:
+
+- Zero versions: create one and capture `.data.id` as `IAP_VERSION_ID`.
+- One version: reuse `.data[0].id`.
+- More than one: stop and require an explicit version ID.
+
+Create only in the zero-result branch:
+
+```bash
+asc iap versions create --iap-id "IAP_ID" --output json
+```
+
+Resolve and repair the intended localization:
+
+```bash
+asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output json
+asc iap versions localizations create --version-id "IAP_VERSION_ID" --locale "en-US" --name "Premium" --description "Unlock premium features"
+asc iap versions localizations update --localization-id "IAP_LOC_ID" --name "Premium" --description "Unlock premium features"
+```
+
+Create only when `en-US` is absent. Update only when one resolved localization differs.
+
+Resolve images before writing:
+
+```bash
+asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output json
+```
+
+Create an image only when the intended file is absent:
+
+```bash
+asc iap versions images create --version-id "IAP_VERSION_ID" --file "./review.png"
+```
+
+Treat replacement as a separate confirmed branch:
+
+```bash
+asc iap versions images delete --image-id "IAP_IMAGE_ID" --confirm
+asc iap versions images create --version-id "IAP_VERSION_ID" --file "./review.png"
+```
+
+Inspect the version and return its ID to `asc-release-flow`:
+
+```bash
+asc iap versions view --version-id "IAP_VERSION_ID" --output table
+asc iap versions localizations list --version-id "IAP_VERSION_ID" --paginate --output table
+asc iap versions image --version-id "IAP_VERSION_ID" --output table
+asc iap versions images list --version-id "IAP_VERSION_ID" --paginate --output table
+```
+
+Do not add the version to a review submission from this skill. Hand `IAP_VERSION_ID` to the multi-item workflow in `asc-release-flow`.
+
+## Handle first-version IAP attachment
+
+Apple may require the first IAP, a new IAP type, or a non-renewing IAP to be selected with the next app version. Prepare localization, pricing, and review screenshots first.
+
+Use the web-session fallback only for that public-API gap:
+
+```bash
+asc web review iaps attach --app "APP_ID" --iap-id "IAP_ID" --confirm
+```
+
+Say that the command requires an authenticated Apple web session. Keep manual selection in the app version's “In-App Purchases and Subscriptions” section as the fallback.

--- a/skills/asc-submission-health/references/readiness-repairs.md
+++ b/skills/asc-submission-health/references/readiness-repairs.md
@@ -106,7 +106,7 @@ asc apps info list --app "APP_ID" --output table
 asc localizations list --app "APP_ID" --type app-info --app-info "APP_INFO_ID" --output table
 ```
 
-For apps with subscriptions or IAPs, populate the privacy policy URL when missing:
+For every iOS or macOS app, populate the privacy policy URL when missing:
 
 ```bash
 asc app-setup info set \

--- a/skills/asc-submission-health/references/readiness-repairs.md
+++ b/skills/asc-submission-health/references/readiness-repairs.md
@@ -1,0 +1,186 @@
+# Readiness repairs
+
+Read only the section that matches a proven `asc validate` or `asc review doctor` blocker.
+
+## Contents
+
+- [Build processing and encryption](#build-processing-and-encryption)
+- [Content rights](#content-rights)
+- [Age rating](#age-rating)
+- [Version metadata and localizations](#version-metadata-and-localizations)
+- [App info and privacy policy URL](#app-info-and-privacy-policy-url)
+- [Screenshots](#screenshots)
+- [Initial availability](#initial-availability)
+- [Review details](#review-details)
+
+## Build processing and encryption
+
+Inspect the exact build before editing declarations:
+
+```bash
+asc builds info --build-id "BUILD_ID" --output table
+```
+
+Require `processingState` to be `VALID`. If encryption remains unresolved, inspect existing declarations:
+
+```bash
+asc encryption declarations list --app "APP_ID" --output table
+```
+
+Create a declaration only when its answers accurately describe the binary:
+
+```bash
+asc encryption declarations create \
+  --app "APP_ID" \
+  --app-description "Uses standard HTTPS/TLS" \
+  --contains-proprietary-cryptography=false \
+  --contains-third-party-cryptography=true \
+  --available-on-french-store=true
+```
+
+Assign the declaration to the resolved build:
+
+```bash
+asc encryption declarations assign-builds --id "DECLARATION_ID" --build "BUILD_ID"
+```
+
+If the app truly uses only exempt transport encryption, update the local plist and rebuild instead of making a false declaration:
+
+```bash
+asc encryption declarations exempt-declare --plist "./Info.plist"
+```
+
+## Content rights
+
+Read the current declaration, then edit it only when the answer is known:
+
+```bash
+asc apps content-rights view --app "APP_ID" --output table
+asc apps content-rights edit --app "APP_ID" --uses-third-party-content=false
+```
+
+## Age rating
+
+Inspect the full declaration before a partial edit:
+
+```bash
+asc age-rating view --app "APP_ID" --output table
+```
+
+Set the social-media fields only when they describe the app:
+
+```bash
+asc age-rating edit --app "APP_ID" --social-media false --social-media-age-restricted false
+```
+
+Apple requires `userGeneratedContent=true` before `socialMedia` can be true. It requires both `ageAssurance=true` and `socialMedia=true` before `socialMediaAgeRestricted` can be true. Set every required prerequisite in the same edit or preserve the current values explicitly.
+
+Use `--age-rating-override-v2` when an override is required. The older `--age-rating-override` flag is deprecated.
+
+## Version metadata and localizations
+
+Inspect the version and its attached resources:
+
+```bash
+asc versions view --version-id "VERSION_ID" --include-build --include-submission --output table
+asc localizations list --version "VERSION_ID" --output table
+```
+
+Use the canonical metadata workflow for repair:
+
+```bash
+asc metadata pull --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
+asc metadata validate --dir "./metadata" --output table
+asc metadata push --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata" --dry-run --output table
+asc metadata push --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata"
+```
+
+Review the dry-run diff before applying metadata. Do not overwrite local changes with a pull unless the user has chosen the remote copy as the source of truth.
+
+## App info and privacy policy URL
+
+Resolve the app-info record and its localizations:
+
+```bash
+asc apps info list --app "APP_ID" --output table
+asc localizations list --app "APP_ID" --type app-info --app-info "APP_INFO_ID" --output table
+```
+
+For apps with subscriptions or IAPs, populate the privacy policy URL when missing:
+
+```bash
+asc app-setup info set \
+  --app "APP_ID" \
+  --primary-locale "en-US" \
+  --privacy-policy-url "https://example.com/privacy"
+```
+
+## Screenshots
+
+Inspect the localization's current screenshot set and the accepted dimensions:
+
+```bash
+asc screenshots list --version-localization "LOC_ID" --output table
+asc screenshots sizes --output table
+asc screenshots validate --path "./screenshots" --device-type "IPHONE_65" --output table
+```
+
+Use `asc-screenshot-resize` or `asc-shots-pipeline` for screenshot production. Return here after the files pass validation and are uploaded.
+
+## Initial availability
+
+First confirm that no availability record exists:
+
+```bash
+asc pricing availability view --app "APP_ID" --output table
+```
+
+Bootstrap the first record through the public API:
+
+```bash
+asc pricing availability create \
+  --app "APP_ID" \
+  --territory "USA,GBR" \
+  --available true \
+  --available-in-new-territories true
+```
+
+Use the edit command only after a record exists:
+
+```bash
+asc pricing availability edit \
+  --app "APP_ID" \
+  --territory "USA,GBR" \
+  --available true \
+  --available-in-new-territories true
+```
+
+Do not assume a standard territory list. Ask the user which territories should receive the app.
+
+## Review details
+
+Inspect the version's review details:
+
+```bash
+asc review details-for-version --version-id "VERSION_ID" --output table
+```
+
+Create missing details:
+
+```bash
+asc review details-create \
+  --version-id "VERSION_ID" \
+  --contact-first-name "Dev" \
+  --contact-last-name "Support" \
+  --contact-email "dev@example.com" \
+  --contact-phone "+1 555 0100" \
+  --notes "Explain the reviewer access path here."
+```
+
+Update the resolved record instead of creating a duplicate:
+
+```bash
+asc review details-update --id "DETAIL_ID" --notes "Updated reviewer instructions."
+```
+
+Set demo-account fields only when App Review needs credentials, and never print secrets in logs or handoff text.


### PR DESCRIPTION
## What changed

- make `asc-release-flow` own staging, upload, publishing, prepared submission, and multi-item submission assembly
- make `asc-submission-health` own readiness diagnosis, blocker repair routing, review monitoring, cancellation, and retry decisions
- move IAP, subscriptions, App Privacy, readiness repairs, and multi-item details into conditional references
- update README routing and explicit handoffs between the two skills

## Impact

- always-loaded skill content drops from 772 lines to 320 lines
- operational command overlap drops from 29 paths to only the shared `asc validate` gate
- Game Center preparation stays in the release multi-item reference; digital-goods repair stays in submission health

## Verification

- audited active commands and flags against an isolated ASC 3.1.1 build at commit `cf3457b`
- `uvx --from skills-ref@0.1.1 agentskills validate skills/asc-release-flow`
- `uvx --from skills-ref@0.1.1 agentskills validate skills/asc-submission-health`
- `quick_validate.py` passed for both skills
- `git diff --check`

This branch is based directly on `upstream/main` and does not include plugin PR #54.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/app-store-connect-cli-skills/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787221233&installation_model_id=10418&pr_number=55&repository=rorkai%2Fapp-store-connect-cli-skills&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2Fapp-store-connect-cli-skills%2Fpull%2F55&signature=6eeb9c5109c7d8b25b70671846c0f42a17338bc026cfe9fe10a0d4708bc96aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the main README and skill descriptions to clarify staging-to-publish-to-submit orchestration, with dry-run and confirmation-gated execution.
  * Reworked the release orchestration guide into a lane-based, readiness-gated workflow and clarified safe publish/submit and release handoffs.
  * Expanded submission-health into a structured “review health” playbook for diagnosing blockers, routing repairs, monitoring review state, and using confirmation-gated cancel/retry guardrails.
  * Added/updated reference guides for multi-item review submissions, App Privacy validation, digital-goods readiness, and step-by-step readiness repairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->