### PR TITLE
fix: sync skills with asc 3.3.0

### DIFF
--- a/skills/asc-metadata-sync/SKILL.md
+++ b/skills/asc-metadata-sync/SKILL.md
@@ -142,7 +142,7 @@ Use this only for existing fastlane-format trees:
 asc migrate export --app "APP_ID" --version-id "VERSION_ID" --output-dir "./fastlane"
 asc migrate validate --fastlane-dir "./fastlane"
 asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir "./fastlane" --dry-run
-asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir "./fastlane"
+asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir "./fastlane" --confirm
 ```
 
 ## Character limits

--- a/skills/asc-ppp-pricing/SKILL.md
+++ b/skills/asc-ppp-pricing/SKILL.md
@@ -131,6 +131,7 @@ Apply for real:
 asc subscriptions pricing prices import \
   --subscription-id "SUB_ID" \
   --input "./ppp-prices.csv" \
+  --confirm \
   --output table
 ```
 


### PR DESCRIPTION
## Summary

- add the required `--confirm` flags to mutation examples for subscription-price imports and Fastlane metadata imports
- replace the obsolete web-session initial-availability guidance with `asc pricing availability create`
- list the new public availability-create command in general CLI guidance

## CLI evidence

Validated against `asc` 3.3.0 (`658ea25dcc530a2c733146b84bc8b2ade16f4aad`):

- `asc subscriptions pricing prices import --help` requires `--confirm` unless `--dry-run`
- `asc migrate import --help` requires `--confirm` unless `--dry-run`
- `asc pricing availability create --help` requires `--app`, `--territory`, `--available`, and `--available-in-new-territories`; it initializes the first availability record through the public API

## Validation

- built `asc` 3.3.0 and checked help for every changed command
- parser/runtime checks reached expected auth or missing-input errors, with no flag errors
- ran `quick_validate.py` successfully on all five changed skills
- ran `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/app-store-connect-cli-skills/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788068310&installation_model_id=10418&pr_number=56&repository=rorkai%2Fapp-store-connect-cli-skills&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2Fapp-store-connect-cli-skills%2Fpull%2F56&signature=b8d174fa2a42e52d7981b131958aa53284c9ca7dd7022e1e4e635e7feee61fd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated metadata import instructions to require an explicit `--confirm` flag before applying changes.
  * Updated subscription pricing import examples to include `--confirm` after reviewing the dry run.
  * Clarified the command-line workflow for safely executing both import operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->