### PR TITLE
feat: add ASC analytics collection skill

### DIFF
--- a/.github/workflows/validate-plugin-packaging.yml
+++ b/.github/workflows/validate-plugin-packaging.yml
@@ -44,10 +44,10 @@ jobs:
             agentskills validate "${skill_dir}"
             skill_count=$((skill_count + 1))
           done
-          test "${skill_count}" -eq 23
+          test "${skill_count}" -eq 24
 
       - name: Validate cross-host manifests
-        run: python scripts/validate-plugin-packaging.py . --expected-skills 23
+        run: python scripts/validate-plugin-packaging.py . --expected-skills 24
 
       - name: Test packaging validator
         run: python -m unittest discover -s tests -p 'test_*.py'
@@ -77,7 +77,7 @@ jobs:
           installed_path="$(jq -er '.installedPath' <<<"${install_json}")"
           test -d "${installed_path}/skills"
           skill_count="$(find "${installed_path}/skills" -mindepth 2 -maxdepth 2 -type f -name SKILL.md | wc -l | tr -d ' ')"
-          test "${skill_count}" -eq 23
+          test "${skill_count}" -eq 24
 
       - name: Validate and load Claude plugin
         shell: bash
@@ -91,7 +91,7 @@ jobs:
           CLAUDE_CONFIG_DIR="${asc_claude_config_dir}" claude plugin install asc@rorkai
           details="$(CLAUDE_CONFIG_DIR="${asc_claude_config_dir}" claude plugin details asc@rorkai)"
           printf '%s\n' "${details}"
-          grep -F "Skills (23)" <<<"${details}"
+          grep -F "Skills (24)" <<<"${details}"
 
       # Codex CLI 0.144.1 has no plugin validation subcommand, so its manifest is
       # checked by the repository validator and loaded from a disposable CI-only

--- a/README.md
+++ b/README.md
@@ -223,6 +223,21 @@ Run an offline ASO audit on canonical App Store metadata under `./metadata` and 
 Audit ./metadata for ASO problems, then show the highest-value keyword gaps from Astro for my latest version.
 ```
 
+### asc-analytics-reports
+
+Collect, download, and verify private App Store Connect Analytics reports with `asc`.
+
+**Use when:**
+- You need to find an existing analytics report request
+- You want report instances filtered by processing date or granularity
+- You need every report segment downloaded and checked against Apple's size and MD5 metadata
+
+**Example:**
+
+```bash
+Collect my latest weekly analytics reports, download every segment privately, and verify each file before analysis.
+```
+
 ### asc-whats-new-writer
 
 Generate engaging, localized App Store release notes from git log, bullet points, or free text using canonical metadata under `./metadata`.

--- a/scripts/validate-plugin-packaging.py
+++ b/scripts/validate-plugin-packaging.py
@@ -59,8 +59,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--expected-skills",
         type=int,
-        default=23,
-        help="Expected number of packaged skills (default: 23)",
+        default=24,
+        help="Expected number of packaged skills (default: 24)",
     )
     return parser.parse_args()
 

--- a/skills/asc-analytics-reports/SKILL.md
+++ b/skills/asc-analytics-reports/SKILL.md
@@ -75,17 +75,29 @@ asc --profile "$APPROVED_PROFILE" analytics request \
   --app "$APP_ID" \
   --access-type "$ACCESS_TYPE" \
   --reuse-existing \
-  --output json
+  --output json \
+  > "$ASC_ANALYTICS_DIR/request.json" \
+  2> "$ASC_ANALYTICS_DIR/request.stderr"
 ```
 
-Do not run that command without explicit approval.
+Do not run that command without explicit approval. Read the returned request ID
+from the private JSON response before continuing:
+
+```bash
+REQUEST_ID="$(jq -er '.requestId' "$ASC_ANALYTICS_DIR/request.json")"
+```
+
+When a request was created or reused with the approved profile, set
+`ANALYTICS_PROFILE="$APPROVED_PROFILE"`. For an existing request discovered
+with the read-only profile, set `ANALYTICS_PROFILE="$PROFILE"`. Use that same
+profile for every subsequent `analytics view` and `analytics download` call.
 
 ## 4. Discover and select report instances
 
 First retrieve report and instance metadata without segment URLs:
 
 ```bash
-asc --profile "$PROFILE" analytics view \
+asc --profile "$ANALYTICS_PROFILE" analytics view \
   --request-id "$REQUEST_ID" \
   --paginate \
   --output json \
@@ -95,14 +107,18 @@ asc --profile "$PROFILE" analytics view \
 
 Select an available `processingDate` and the granularity requested by the user.
 Accept `DAILY`, `WEEKLY`, and `MONTHLY`, individually or as a comma-separated
-list. Normalize user input to uppercase and preserve only requested values.
+list. Split the input on commas, trim each token, and normalize it to uppercase.
+Validate every token against that allowlist, including empty tokens. Report the
+invalid input and stop before running `analytics view`; never silently discard
+unsupported values or continue with an empty filter. After validation, remove
+duplicates and join the remaining values with commas.
 Treat `processingDate` as the date Apple processed the report, not necessarily
 the period represented by its rows.
 
 Retrieve the filtered inventory, including all segment metadata:
 
 ```bash
-asc --profile "$PROFILE" analytics view \
+asc --profile "$ANALYTICS_PROFILE" analytics view \
   --request-id "$REQUEST_ID" \
   --processing-date "$PROCESSING_DATE" \
   --granularity "$GRANULARITY" \
@@ -126,7 +142,7 @@ Download each segment by its request, instance, and segment IDs. Use a filename
 derived only from the segment ID and keep the compressed bytes intact:
 
 ```bash
-asc --profile "$PROFILE" analytics download \
+asc --profile "$ANALYTICS_PROFILE" analytics download \
   --request-id "$REQUEST_ID" \
   --instance-id "$INSTANCE_ID" \
   --segment-id "$SEGMENT_ID" \

--- a/skills/asc-analytics-reports/SKILL.md
+++ b/skills/asc-analytics-reports/SKILL.md
@@ -14,8 +14,8 @@ aggregate, or present the report contents as part of this skill.
 - Treat report inventories, signed URLs, downloaded segments, and identifiers as
   confidential business data.
 - Prefer an existing request. Creating a request changes App Store Connect state
-  and may require an Admin-authorized profile; obtain explicit user approval
-  before running `asc analytics request`.
+  and requires an Admin-authorized profile; obtain explicit user approval before
+  running `asc analytics request`.
 - Never delete or replace a request as part of collection.
 - Use `asc analytics download`; do not fetch or persist signed segment URLs
   separately.
@@ -139,14 +139,16 @@ segments and retain each segment's exact ID, `sizeInBytes`, and `checksum` for
 verification. Do not print `downloadUrl`.
 
 Download each segment by its request, instance, and segment IDs. Use a filename
-derived only from the segment ID and keep the compressed bytes intact:
+derived only from the segment ID and keep the compressed bytes intact. Analytics
+reports are tab-delimited text, so use `.txt.gz` rather than implying CSV:
 
 ```bash
+SEGMENT_FILE="$ASC_ANALYTICS_DIR/segments/$SEGMENT_ID.txt.gz"
 asc --profile "$ANALYTICS_PROFILE" analytics download \
   --request-id "$REQUEST_ID" \
   --instance-id "$INSTANCE_ID" \
   --segment-id "$SEGMENT_ID" \
-  --output "$ASC_ANALYTICS_DIR/segments/$SEGMENT_ID.csv.gz" \
+  --output "$SEGMENT_FILE" \
   > /dev/null \
   2>> "$ASC_ANALYTICS_DIR/download.stderr"
 ```
@@ -167,9 +169,12 @@ expected_md5="$(printf '%s' "$CHECKSUM" | tr '[:upper:]' '[:lower:]')"
 
 Require `actual_size` to equal `sizeInBytes` and `actual_md5` to equal
 `expected_md5`. On a mismatch, mark that segment failed, keep the raw error
-private, and do not claim a complete collection. Redownload only the failed
-segment using `asc analytics download`, then verify it again. Do not parse or
-analyze a file until verification succeeds.
+private, and do not claim a complete collection. `asc analytics download`
+refuses to overwrite an existing output, so retry the failed segment once to a
+new path such as `$ASC_ANALYTICS_DIR/segments/$SEGMENT_ID.retry-1.txt.gz`. Verify
+the retry independently and use it only if both checks pass. Keep the original
+failed file unless the user approves its deletion. Do not parse or analyze a
+file until verification succeeds.
 
 ## 7. Report the result
 

--- a/skills/asc-analytics-reports/SKILL.md
+++ b/skills/asc-analytics-reports/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: asc-analytics-reports
+description: Collect, download, and verify App Store Connect Analytics reports with asc. Use when users need to discover analytics report requests, select report instances by processing date or granularity, download every segment, or verify downloaded files against Apple's size and MD5 metadata before analysis.
+---
+
+# asc analytics reports
+
+Collect a complete set of analytics report segments and verify the compressed
+files before handing them to a separate analysis workflow. Do not interpret,
+aggregate, or present the report contents as part of this skill.
+
+## Guardrails
+
+- Treat report inventories, signed URLs, downloaded segments, and identifiers as
+  confidential business data.
+- Prefer an existing request. Creating a request changes App Store Connect state
+  and may require an Admin-authorized profile; obtain explicit user approval
+  before running `asc analytics request`.
+- Never delete or replace a request as part of collection.
+- Use `asc analytics download`; do not fetch or persist signed segment URLs
+  separately.
+- Store private files outside the source repository with owner-only permissions.
+- Do not claim the collection is complete if any expected segment is missing or
+  fails verification.
+
+## 1. Verify the CLI contract
+
+Inspect the installed command before authentication or collection:
+
+```bash
+asc analytics view --help
+```
+
+Continue only when help lists `--processing-date`, `--granularity`,
+`--paginate`, and `--include-segments`. These filters require asc 3.5.0 or
+newer. If either filter is absent, ask the user to upgrade. Do not substitute
+the deprecated `--date` flag because it uses legacy local matching rather than
+Apple's server-side processing-date filter.
+
+## 2. Prepare private storage
+
+Create a private temporary directory outside the repository before capturing
+JSON or downloading segments:
+
+```bash
+umask 077
+ASC_ANALYTICS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/asc-analytics.XXXXXX")"
+mkdir -m 700 "$ASC_ANALYTICS_DIR/segments"
+```
+
+Redirect command output and errors into this directory. Do not paste raw
+inventory JSON or error output into chat, commits, issues, or pull requests.
+
+## 3. Find an existing request
+
+Resolve the app ID and selected asc profile, then list every request:
+
+```bash
+asc --profile "$PROFILE" analytics requests \
+  --app "$APP_ID" \
+  --paginate \
+  --output json \
+  > "$ASC_ANALYTICS_DIR/requests.json" \
+  2> "$ASC_ANALYTICS_DIR/requests.stderr"
+```
+
+Inspect the JSON structurally and select an existing usable request. Do not rely
+on `--state` when discovery works without it. If no usable request exists, stop
+and ask whether the user wants to create `ONGOING` or `ONE_TIME_SNAPSHOT`
+access. State the target app and profile before requesting approval. After
+approval, prefer `--reuse-existing` to avoid duplicates:
+
+```bash
+asc --profile "$APPROVED_PROFILE" analytics request \
+  --app "$APP_ID" \
+  --access-type "$ACCESS_TYPE" \
+  --reuse-existing \
+  --output json
+```
+
+Do not run that command without explicit approval.
+
+## 4. Discover and select report instances
+
+First retrieve report and instance metadata without segment URLs:
+
+```bash
+asc --profile "$PROFILE" analytics view \
+  --request-id "$REQUEST_ID" \
+  --paginate \
+  --output json \
+  > "$ASC_ANALYTICS_DIR/discovery.json" \
+  2> "$ASC_ANALYTICS_DIR/discovery.stderr"
+```
+
+Select an available `processingDate` and the granularity requested by the user.
+Accept `DAILY`, `WEEKLY`, and `MONTHLY`, individually or as a comma-separated
+list. Normalize user input to uppercase and preserve only requested values.
+Treat `processingDate` as the date Apple processed the report, not necessarily
+the period represented by its rows.
+
+Retrieve the filtered inventory, including all segment metadata:
+
+```bash
+asc --profile "$PROFILE" analytics view \
+  --request-id "$REQUEST_ID" \
+  --processing-date "$PROCESSING_DATE" \
+  --granularity "$GRANULARITY" \
+  --paginate \
+  --include-segments \
+  --output json \
+  > "$ASC_ANALYTICS_DIR/inventory.json" \
+  2> "$ASC_ANALYTICS_DIR/inventory.stderr"
+```
+
+Always use `--paginate`; asc follows Apple-provided report and instance next
+links. Do not reconstruct, alter, or follow pagination URLs manually.
+
+## 5. Download every segment
+
+Parse `inventory.json` structurally. For every selected instance, enumerate all
+segments and retain each segment's exact ID, `sizeInBytes`, and `checksum` for
+verification. Do not print `downloadUrl`.
+
+Download each segment by its request, instance, and segment IDs. Use a filename
+derived only from the segment ID and keep the compressed bytes intact:
+
+```bash
+asc --profile "$PROFILE" analytics download \
+  --request-id "$REQUEST_ID" \
+  --instance-id "$INSTANCE_ID" \
+  --segment-id "$SEGMENT_ID" \
+  --output "$ASC_ANALYTICS_DIR/segments/$SEGMENT_ID.csv.gz" \
+  > /dev/null \
+  2>> "$ASC_ANALYTICS_DIR/download.stderr"
+```
+
+Do not use `--decompress` before verification. If an instance has multiple
+segments, download every one; never treat the first segment as the whole report.
+
+## 6. Verify the downloaded files
+
+For each file, compare the compressed byte count with `sizeInBytes` and the
+lowercase MD5 digest with `checksum`. Use local system tools such as:
+
+```bash
+actual_size="$(wc -c < "$SEGMENT_FILE" | tr -d ' ')"
+actual_md5="$(openssl dgst -md5 -r "$SEGMENT_FILE" | awk '{print tolower($1)}')"
+expected_md5="$(printf '%s' "$CHECKSUM" | tr '[:upper:]' '[:lower:]')"
+```
+
+Require `actual_size` to equal `sizeInBytes` and `actual_md5` to equal
+`expected_md5`. On a mismatch, mark that segment failed, keep the raw error
+private, and do not claim a complete collection. Redownload only the failed
+segment using `asc analytics download`, then verify it again. Do not parse or
+analyze a file until verification succeeds.
+
+## 7. Report the result
+
+Return a concise summary containing:
+
+- the selected processing date and granularity values;
+- counts of reports, instances, expected segments, downloaded segments, and
+  verified segments;
+- whether the collection is complete;
+- failed or missing segment IDs, if any, without signed URLs or report rows;
+- the private output directory when appropriate for the current user session.
+
+Do not include analytics values, signed URLs, profile names, credentials, or raw
+rows in a public artifact. Keep the verified files for the user's next workflow.
+Ask before deleting the temporary directory or any downloaded evidence.


### PR DESCRIPTION
## Summary

- add a focused `asc-analytics-reports` skill for collecting App Store Connect Analytics reports
- guide agents through request discovery, server-side processing-date and granularity filtering, complete segment downloads, and size/MD5 verification
- update the README catalog and packaged skill count from 23 to 24

## Context

This is the deliberately smaller follow-up to #57, based directly on the maintainer's feedback that this repository should teach focused workflows around `asc` rather than maintain a standalone analytics product.

The skill consumes the command contract added in [App Store Connect CLI PR #1840](https://github.com/rorkai/App-Store-Connect-CLI/pull/1840):

```bash
asc analytics view \
  --request-id "$REQUEST_ID" \
  --processing-date "$PROCESSING_DATE" \
  --granularity "$GRANULARITY" \
  --paginate \
  --include-segments \
  --output json
```

That CLI change makes it possible to select the required instances through Apple's server-side filters while preserving the existing JSON contract and pagination behavior.

## Workflow added

The skill teaches an agent to:

1. feature-detect asc 3.5.0's `--processing-date` and `--granularity` flags;
2. create owner-only temporary storage outside the source repository;
3. discover and reuse an existing analytics report request;
4. select an available processing date and one or more documented granularities;
5. retrieve a fully paginated inventory with segment metadata;
6. download every segment through `asc analytics download` without following signed URLs directly;
7. verify each compressed file against Apple's `sizeInBytes` and MD5 `checksum` values;
8. report a sanitized completeness summary without exposing analytics or credentials.

Request creation is never implicit. If no usable request exists, the skill stops and requires explicit approval before running the mutating `asc analytics request` command. It never deletes or replaces requests.

## Scope boundary

This PR contains one instruction-only skill. It intentionally does not include:

- an executable analytics or evidence engine;
- custom schemas or report parsers;
- metric aggregation or financial calculations;
- acquisition, investor, dossier, presentation, or valuation generation;
- plugin manifest or version changes.

Any higher-level analytics product remains separate from this repository. This contribution stops after a complete, integrity-checked private collection is ready for another workflow.

## Privacy and integrity

- Inventories, signed URLs, identifiers, errors, and downloaded files remain in an owner-only temporary directory.
- Segment URLs are not fetched or persisted independently; downloads go through `asc` using exact IDs.
- Every expected segment must be downloaded and match both byte size and MD5 before the collection is considered complete.
- Raw analytics, signed URLs, profile names, and credentials are excluded from public summaries.
- Temporary evidence is not deleted without user approval.

## Repository integration

- adds `skills/asc-analytics-reports/SKILL.md`;
- adds the skill to the README catalog;
- updates the packaging validator and CI host-loading assertions from 23 to 24 skills;
- leaves existing skills, plugin manifests, and plugin versions unchanged.

## Verification

- the new skill passes the skill-creator validator;
- all 24 skills pass `agentskills validate` with `skills-ref==0.1.1`;
- cross-host packaging validation passes with 24 skills;
- all repository unit tests pass on Python 3.10 and 3.12;
- disposable Codex 0.144.1 and Claude Code 2.1.198 installations each discover all 24 skills;
- the commands and flags were checked against the official asc 3.5.0 release and current CLI source;
- `git diff --check` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/app-store-connect-cli-skills/pr/58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788440687&installation_model_id=10418&pr_number=58&repository=rorkai%2Fapp-store-connect-cli-skills&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2Fapp-store-connect-cli-skills%2Fpull%2F58&signature=c6ca7feda92b0e4ead19a6c256afd7d1d3c387bb02f8d1c306ac2a5036390ff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance for discovering, filtering, downloading, and verifying private App Store analytics reports.
  * Added safeguards for approval-gated requests, report completeness, segment verification, retries, and secure handling of report data.
* **Documentation**
  * Documented the new analytics reporting capability and its supported workflows.
* **Chores**
  * Updated packaging validation to recognize the expanded set of 24 available skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->