### PR TITLE
docs: add Pass Type ID signing workflow

### DIFF
--- a/skills/asc-signing-setup/SKILL.md
+++ b/skills/asc-signing-setup/SKILL.md
@@ -26,6 +26,10 @@ Use this skill when you need to create or renew signing assets for iOS/macOS app
    - `asc certificates create --certificate-type IOS_DISTRIBUTION --csr "./cert.csr"`
    - Or generate a key and CSR inline:
      - `asc certificates create --certificate-type IOS_DISTRIBUTION --generate-csr --key-out "./signing/dist.key" --csr-out "./signing/dist.csr"`
+   - For Wallet passes, create the Pass Type ID first, then create its certificate:
+     - `asc pass-type-ids create --identifier "pass.com.example" --name "Example Pass"`
+     - `asc certificates create --certificate-type PASS_TYPE_ID --pass-type-id "PASS_TYPE_ID" --csr "./pass.csr"`
+     - `asc pass-type-ids certificates list --pass-type-id "PASS_TYPE_ID" --paginate`
 4. Create a provisioning profile:
    - `asc profiles create --name "AppStore Profile" --profile-type IOS_APP_STORE --bundle "BUNDLE_ID" --certificate "CERT_ID"`
    - Include devices for development/ad-hoc:


### PR DESCRIPTION
## Proven drift

ASC CLI `3.5.0` added Pass Type ID certificate support, but `asc-signing-setup` only documented iOS/macOS certificate flows.

Built `asc 3.5.0` evidence:

- `asc pass-type-ids create --identifier "pass.com.example" --name "Example"`
- `asc certificates create --certificate-type PASS_TYPE_ID --pass-type-id "PASS_TYPE_ID" --csr "./pass.csr"`
- `asc pass-type-ids certificates list --pass-type-id "PASS_TYPE_ID" --paginate`

## Validation

- Built release binary help verified each command and flag.
- `quick_validate.py skills/asc-signing-setup` passed.
- `git diff --check` passed.

No live App Store Connect mutations were performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/app-store-connect-cli-skills/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788498930&installation_model_id=10418&pr_number=59&repository=rorkai%2Fapp-store-connect-cli-skills&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2Fapp-store-connect-cli-skills%2Fpull%2F59&signature=e5d077409f6b5b96946b910ae4ed0d3cd447fe8d36ad7e7dd55c0443b3faeab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added instructions for setting up Wallet pass signing.
  - Covers creating a Pass Type ID, issuing a certificate with a CSR, and viewing available certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->