### PR TITLE
docs: document Xcode settings lookup policy

### DIFF
--- a/skills/asc-xcode-build/SKILL.md
+++ b/skills/asc-xcode-build/SKILL.md
@@ -34,6 +34,8 @@ asc xcode version edit --next-build-number --app "APP_ID" --platform IOS --outpu
 
 Version mutations validate the full change before writing and return structured output identifying the configurations and files changed. The editor follows recursive xcconfig includes and preserves unrelated project and xcconfig content. Use `asc builds next-build-number` separately when you only want to inspect the remote-safe value without changing the project.
 
+Version commands read project and xcconfig settings without launching Xcode. When those settings cannot resolve the version values, the default `--xcodebuild-settings-lookup auto` falls back to `xcodebuild -showBuildSettings` and warns on stderr. Use `--xcodebuild-settings-lookup never` in automation that must not launch Xcode implicitly.
+
 ## Preferred iOS/tvOS/visionOS build flow
 
 ### 1. Archive with asc


### PR DESCRIPTION
## Summary
- document the v3.5.0 Xcode version-command fallback policy
- clarify `auto` warns before `xcodebuild -showBuildSettings` and `never` disables the implicit launch

## CLI evidence
- Release: `3.5.0` (`cafc04f0`, 2026-08-03)
- `asc xcode version view --help`, `edit --help`, and `bump --help` each expose `[experimental] --xcodebuild-settings-lookup auto|never` (default `auto`).
- Verified against a local binary built from tag `3.5.0`.

## Validation
- Validated help paths: `xcode version view`, `edit`, `bump`, `archive`, `export`, `export-options generate`, `builds upload`, and `publish appstore`.
- `agentskills validate` for all 23 skills
- `python3 scripts/validate-plugin-packaging.py . --expected-skills 23`
- `python3 -m unittest discover -s tests -p "test_*.py"`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/app-store-connect-cli-skills/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788500089&installation_model_id=10418&pr_number=60&repository=rorkai%2Fapp-store-connect-cli-skills&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2Fapp-store-connect-cli-skills%2Fpull%2F60&signature=679a036cae885458fc15691684c96990b5b888de4979837a33cd5e5cd4d4bd91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented how Xcode version settings are determined.
  * Added details about fallback behavior, stderr warnings, and the option to prevent automatic Xcode launches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->