### PR TITLE
docs: sync web API key and iCloud signing guidance

### DIFF
--- a/skills/asc-cli-usage/SKILL.md
+++ b/skills/asc-cli-usage/SKILL.md
@@ -54,6 +54,10 @@ Use this skill when you need to run or design `asc` commands for App Store Conne
 - When permissions are unclear, inspect exact API key role coverage with `asc web auth capabilities`.
   - This lives under the web-session auth surface.
   - It can resolve the current local auth by default, or inspect a specific key with `--key-id`.
+- Create an App Store Connect team API key through a cached Apple Account web session with `asc web api-keys create`.
+  - An Account Holder or Admin session is required; use `asc web auth login --apple-id "user@example.com"` first when needed.
+  - The command saves the one-time P8 as `AuthKey_<KEY_ID>.p8` without printing its contents; choose an explicit private directory with `--output-dir`.
+  - Example: `asc web api-keys create --name "CI uploads" --role APP_MANAGER --output-dir "./keys" --output json`.
 
 ## Apple Ads
 - Use `asc ads --help` before choosing a command.

--- a/skills/asc-signing-setup/SKILL.md
+++ b/skills/asc-signing-setup/SKILL.md
@@ -20,7 +20,7 @@ Use this skill when you need to create or renew signing assets for iOS/macOS app
    - `asc bundle-ids capabilities list --bundle "BUNDLE_ID"`
    - `asc bundle-ids capabilities add --bundle "BUNDLE_ID" --capability ICLOUD`
    - Add capability settings when required:
-     - `--settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_13","enabled":true}]}]'`
+     - `--settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]'`
 3. Create a signing certificate:
    - `asc certificates list --certificate-type IOS_DISTRIBUTION`
    - `asc certificates create --certificate-type IOS_DISTRIBUTION --csr "./cert.csr"`


### PR DESCRIPTION
## Summary

- document the released `asc web api-keys create` workflow in `asc-cli-usage`
- correct the iCloud capability-settings example in `asc-signing-setup` from stale `XCODE_13` to current `XCODE_6`
- keep one-time P8 and explicit output-directory safety guarantees visible

## CLI evidence

Validated against App Store Connect CLI release `3.5.1` (`315973b4f5185f19d1cf6d9861eacf7b7cf5bb3b`) and the current built checkout `3.5.1-73-ga4be587c` (`a4be587c20c41386442cda3822c8881d53696447`).

```text
asc web api-keys create --name NAME [--role ROLE] [--output-dir DIR] [flags]
asc bundle-ids capabilities add --bundle "BUNDLE_ID" --capability ICLOUD --settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]'\n```\n\nRelease help confirms web API-key role/output constraints and that the one-time P8 is saved, never printed. Current capability help requires structurally valid settings, uses `XCODE_6` in its iCloud example, and accepts the corrected invocation through argument validation.\n\nNo live mutation was run: API-key creation is irreversible/auth-sensitive, and bundle capability changes can affect signing.\n\n## Validation\n\n- `git diff --check`\n- `python3 scripts/validate-plugin-packaging.py --expected-skills 23`\n- `python3 -m unittest discover -s tests -v`\n\nAll passed. This is a documentation-only surface correction and is ready for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating App Store Connect team API keys, including required roles, authentication setup, secure one-time key handling, output location, and an example command.
  * Corrected the iCloud capability configuration example to use the appropriate `XCODE_6` setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->