### PR TITLE
fix: document app availability bootstrap fallback

### DIFF
--- a/skills/asc-app-create-ui/SKILL.md
+++ b/skills/asc-app-create-ui/SKILL.md
@@ -101,7 +101,7 @@ asc pricing availability create \
   --available-in-new-territories true
 ```
 
-Use `asc pricing availability create` only for the first availability bootstrap. If app availability already exists, switch to `asc pricing availability edit --app "APP_ID" ...` for later territory changes.
+Use `asc pricing availability create` only for the first availability bootstrap. If Apple rejects that public-API bootstrap, authenticate a web session with `asc web auth login --apple-id "EMAIL"` and retry with `asc web apps availability create --app "APP_ID" --territory "USA,GBR" --available-in-new-territories true`, or configure Pricing and Availability in App Store Connect. If app availability already exists, switch to `asc pricing availability edit --app "APP_ID" ...` for later territory changes.
 
 ## Known UI Automation Issues
 

--- a/skills/asc-cli-usage/SKILL.md
+++ b/skills/asc-cli-usage/SKILL.md
@@ -32,8 +32,9 @@ Use this skill when you need to run or design `asc` commands for App Store Conne
   - `asc pricing availability edit --app "APP_ID" --territory "USA,GBR" --available true`
   - `asc app-setup availability edit --app "APP_ID" --territory "USA,GBR" --available true`
   - `asc xcode version edit --build-number "42"`
-- Use `asc pricing availability create` to initialize app availability before using the update-only `edit` command.
+- Use `asc pricing availability create` to initialize app availability before using the update-only `edit` command. If Apple rejects the public-API bootstrap, authenticate a web session and use `asc web apps availability create`, or configure Pricing and Availability in App Store Connect.
   - `asc pricing availability create --app "APP_ID" --territory "USA,GBR" --available true --available-in-new-territories true`
+  - `asc web apps availability create --app "APP_ID" --territory "USA,GBR" --available-in-new-territories true`
 - Keep `set` where the CLI intentionally models a higher-level replacement/configuration flow and `--help` still shows `set` as the canonical verb.
 
 ## Flag conventions

--- a/skills/asc-submission-health/references/readiness-repairs.md
+++ b/skills/asc-submission-health/references/readiness-repairs.md
@@ -145,6 +145,17 @@ asc pricing availability create \
   --available-in-new-territories true
 ```
 
+If Apple rejects this public-API bootstrap, it has not configured availability. Authenticate a web session with `asc web auth login --apple-id "EMAIL"`, then retry through the web fallback:
+
+```bash
+asc web apps availability create \
+  --app "APP_ID" \
+  --territory "USA,GBR" \
+  --available-in-new-territories true
+```
+
+Alternatively, configure Pricing and Availability in App Store Connect.
+
 Use the edit command only after a record exists:
 
 ```bash


### PR DESCRIPTION
## Evidence

Validated against App Store Connect CLI `3.5.1` (`315973b4`) and current source build `3.5.1-188-g60601fb7` (`60601fb7`).

`asc pricing availability create --help` now states that Apple can reject the public-API bootstrap and that the command fails without treating availability as configured. `asc web apps availability create --help` confirms the fallback path and flags.

## Changes

- Document the authenticated web-session fallback in the CLI usage skill.
- Add the fallback to app-create handoff and submission-health readiness repair guidance.

## Validation

- `python3 scripts/validate-plugin-packaging.py .`
- `python3 -m unittest discover -s tests -v`
- Built CLI help: `asc pricing availability create --help`; `asc web apps availability create --help`
- Focused CLI tests: `ASC_BYPASS_KEYCHAIN=1 go test ./internal/cli/pricing ./internal/cli/shared ./internal/cli/web -run "Availability|APIKeys" -count=1`

The `skill-creator` quick validator could not run because the default Python environment lacks `PyYAML`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/app-store-connect-cli-skills/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788759420&installation_model_id=10418&pr_number=62&repository=rorkai%2Fapp-store-connect-cli-skills&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2Fapp-store-connect-cli-skills%2Fpull%2F62&signature=a7d8efd344b198f8ad9932a1f11260101e9d4720dae73b4641ac8d5766b26f14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pricing availability guidance for cases where initial setup through the public API is unavailable.
  * Added instructions to authenticate a web session and retry availability setup through the web command.
  * Clarified that availability can also be configured directly in App Store Connect.
  * Preserved existing guidance for editing availability after initial setup.
  * Added the fallback instructions to app creation, CLI usage, and submission readiness documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->