### PR TITLE
docs: cover Developer Portal capability enablement

### DIFF
--- a/skills/asc-signing-setup/SKILL.md
+++ b/skills/asc-signing-setup/SKILL.md
@@ -21,6 +21,12 @@ Use this skill when you need to create or renew signing assets for iOS/macOS app
    - `asc bundle-ids capabilities add --bundle "BUNDLE_ID" --capability ICLOUD`
    - Add capability settings when required:
      - `--settings '[{"key":"ICLOUD_VERSION","options":[{"key":"XCODE_6","enabled":true}]}]'`
+   - For the Developer Portal-only `PRIVATE_CLOUD_COMPUTE` capability, use a
+     user-owned web session and the Developer Portal Bundle ID resource ID:
+     - `asc web bundle-ids capabilities enable --bundle-id "BUNDLE_RESOURCE_ID" --capability PRIVATE_CLOUD_COMPUTE --confirm`
+     - This capability is not available through the public App Store Connect
+       capability enum. If the cached session cannot access Developer Portal,
+       reauthenticate with `asc web auth login --apple-id "user@example.com"`.
 3. Create a signing certificate:
    - `asc certificates list --certificate-type IOS_DISTRIBUTION`
    - `asc certificates create --certificate-type IOS_DISTRIBUTION --csr "./cert.csr"`

--- a/skills/asc-signing-setup/SKILL.md
+++ b/skills/asc-signing-setup/SKILL.md
@@ -25,8 +25,10 @@ Use this skill when you need to create or renew signing assets for iOS/macOS app
      user-owned web session and the Developer Portal Bundle ID resource ID:
      - `asc web bundle-ids capabilities enable --bundle-id "BUNDLE_RESOURCE_ID" --capability PRIVATE_CLOUD_COMPUTE --confirm`
      - This capability is not available through the public App Store Connect
-       capability enum. If the cached session cannot access Developer Portal,
-       reauthenticate with `asc web auth login --apple-id "user@example.com"`.
+     capability enum. If the cached session cannot access Developer Portal,
+       clear its scoped cache, then log in again with the same binary:
+       - `asc web auth logout --apple-id "user@example.com"`
+       - `asc web auth login --apple-id "user@example.com"`
 3. Create a signing certificate:
    - `asc certificates list --certificate-type IOS_DISTRIBUTION`
    - `asc certificates create --certificate-type IOS_DISTRIBUTION --csr "./cert.csr"`


### PR DESCRIPTION
## Summary
- document `asc web bundle-ids capabilities enable` in the signing setup workflow
- scope it to the Developer Portal-only `PRIVATE_CLOUD_COMPUTE` capability and its required web-session authentication

## CLI evidence
- release: `3.7.0` (`4ce50f1165145e3ce829bd6b689ef8aee224de1b`)
- `asc web bundle-ids capabilities enable --help` reports the exact command path, `--bundle-id`, `--capability PRIVATE_CLOUD_COMPUTE`, and required `--confirm`.
- invocation without `--confirm` returns `--confirm is required`, confirming the safe guard before auth or mutation.

## Validation
- `python3 scripts/validate-plugin-packaging.py .`
- `python3 -m unittest discover -s tests -v`
- released 3.7.0 binary help and safe parse validation

The installed skill-creator quick validator could not run because its local Python environment lacks the `yaml` module (`ModuleNotFoundError: No module named yaml`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rorkai/codesmith/app-store-connect-cli-skills/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788932153&installation_model_id=10418&pr_number=63&repository=rorkai%2Fapp-store-connect-cli-skills&return_to=https%3A%2F%2Fgithub.com%2Frorkai%2Fapp-store-connect-cli-skills%2Fpull%2F63&signature=52543bc8cbc25123e6f169d3eedd18a79583cef73cb9679f8ca9f0aba9f88d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for enabling the Developer Portal-only `PRIVATE_CLOUD_COMPUTE` capability through a user-owned web session.
  * Documented a logout-and-login recovery step for Developer Portal access issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->