### PR TITLE
docs: sync workflow and release skills with asc 4.0

### DIFF
--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -61,7 +61,7 @@ If app validation reports a Game Center item blocker, stop and use that preparat
 
 ## Stage an existing build
 
-Use `asc release stage` to ensure the version, apply or copy metadata, attach the selected build, and run validation without creating a review submission.
+Use `asc release stage` to verify the selected build belongs to the app before changing the version, apply or copy metadata, attach the build, and run validation without creating a review submission.
 
 Preview metadata-driven staging:
 
@@ -87,6 +87,12 @@ asc release stage \
 ```
 
 Use `--copy-metadata-from "1.2.2"` instead of `--metadata-dir` when carrying localization metadata forward. Add `--strict-validate` when warnings should fail the stage.
+
+If the metadata plan contains deletes, the dry run and confirmed run both require `--allow-deletes`. Review those deletes first; the flag also disables fallback to an existing locale when that locale is absent locally.
+
+Use `--routing-coverage-file "./coverage.geojson"` when the release includes routing app coverage. This experimental step validates the GeoJSON before mutation and stages it before readiness checks.
+
+Structured output includes a `validate_build` step at the start of `steps[]`. Match steps by name rather than array position.
 
 ## Submit a prepared version
 

--- a/skills/asc-workflow/SKILL.md
+++ b/skills/asc-workflow/SKILL.md
@@ -75,6 +75,8 @@ Do not pass extra `KEY:VALUE` params with `--resume`; the saved workflow file, p
   - `if` conditional var name
   - `with` env overrides for workflow-call steps
   - `outputs` map for JSON stdout extraction from named run steps
+  - `retry` fixed-delay retry policy for a `run` step
+  - `timeout` positive per-attempt duration for a `run` step
 
 ## Outputs
 
@@ -92,6 +94,26 @@ Rules:
 - Outputs are allowed on `run` steps, not workflow-call steps.
 - Output-producing names must be unique across workflows that can execute together in the same run graph.
 - Persisted outputs are stored in workflow run state, so do not map secrets into outputs.
+
+## Bounded retry and timeout
+
+Add retry only to commands you have determined are safe to repeat. The runner does not classify commands or retry mutations on its own.
+
+```json
+{
+  "name": "resolve_build",
+  "run": "asc builds info --app $APP_ID --latest --platform IOS --output json",
+  "retry": {
+    "max_attempts": 3,
+    "delay": "5s"
+  },
+  "timeout": "2m"
+}
+```
+
+`retry.max_attempts` counts the first attempt and must be between 2 and 100. Retry delays and timeouts must be positive durations no longer than 24 hours. Both fields work only on `run` steps, not workflow calls or lifecycle hooks.
+
+A timeout without retry is terminal because the command may have completed remotely. Pairing retry and timeout is the explicit signal that another attempt is safe. Resume requires either a successful checkpoint or a retry-enabled failed step; output-extraction failures cannot be resumed.
 
 ## Runtime params
 


### PR DESCRIPTION
## Summary

- Document bounded workflow retry, per-attempt timeout, and the new resume safety rules.
- Update release staging guidance for build-first validation, guarded metadata deletes, routing coverage, and named step matching.

## CLI evidence

- Release: `4.0.0`, commit `c595cd8db220a83b1bf8298960d2332e2d829ee7`.
- `asc workflow run --help` defines `retry.max_attempts`, fixed `retry.delay`, per-attempt `timeout`, and terminal failure cases.
- `asc release stage --help` lists `--allow-deletes`, `--routing-coverage-file`, and build validation as the first step.

## Validation

- Tagged 4.0.0 command-help checks
- `python3 scripts/validate-plugin-packaging.py . --expected-skills 23`
- `python3 -m unittest discover -s tests -p "test_*.py"`
- `agentskills validate` from `skills-ref==0.1.1` for all 23 skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated staging workflow guidance to verify that selected builds belong to the correct app before version changes.
  * Added instructions for handling metadata deletions, validating routing coverage, and locating build-validation steps in structured output.
  * Documented retry and timeout options for workflow steps, including supported scopes, limits, examples, and resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->