### PR TITLE
docs: cover asc 4.0 build and TestFlight flows

### DIFF
--- a/skills/asc-build-lifecycle/SKILL.md
+++ b/skills/asc-build-lifecycle/SKILL.md
@@ -12,6 +12,7 @@ Use this skill to manage build state, processing, and retention.
   - `asc builds info --app "APP_ID" --latest --version "1.2.3" --platform IOS`
 - Next safe build number:
   - `asc builds next-build-number --app "APP_ID" --version "1.2.3" --platform IOS`
+  - The command scans the full processed-build history and in-flight uploads, then returns one greater than the highest positive numeric build number. Blank or non-numeric processed build numbers are skipped with a warning; if no usable number remains, it falls back to `--initial-build-number`.
 - Recent builds:
   - `asc builds list --app "APP_ID" --sort -uploadedDate --limit 10`
 

--- a/skills/asc-testflight-orchestration/SKILL.md
+++ b/skills/asc-testflight-orchestration/SKILL.md
@@ -26,6 +26,15 @@ Use this skill when managing TestFlight testers, groups, and build distribution.
 - Remove from group:
   - `asc builds remove-groups --build-id "BUILD_ID" --group "GROUP_ID" --confirm`
 
+## Inspect a build's groups
+- `asc testflight groups list --build-id "BUILD_ID" --output table`
+- The build lookup is experimental. It resolves the app, paginates the app's groups, and includes groups with all-build access.
+
+## Upload without distribution
+- `asc publish testflight --app "APP_ID" --ipa "./app.ipa" --upload-only --output json`
+- Add `--wait` when the next step needs a processed build.
+- Upload-only requires a new IPA or local Xcode build. Do not combine it with an existing `--build`, groups, tester notifications, test notes, or beta-review submission. `--build-number` is allowed as upload metadata, but it cannot be the only build input.
+
 ## What to Test notes
 - `asc builds test-notes create --build-id "BUILD_ID" --locale "en-US" --whats-new "Test instructions"`
 - `asc builds test-notes update --localization-id "LOCALIZATION_ID" --whats-new "Updated notes"`

--- a/skills/asc-xcode-build/SKILL.md
+++ b/skills/asc-xcode-build/SKILL.md
@@ -36,6 +36,22 @@ Version mutations validate the full change before writing and return structured 
 
 Version commands read project and xcconfig settings without launching Xcode. When those settings cannot resolve the version values, the default `--xcodebuild-settings-lookup auto` falls back to `xcodebuild -showBuildSettings` and warns on stderr. Use `--xcodebuild-settings-lookup never` in automation that must not launch Xcode implicitly.
 
+## Compile without archiving
+
+Use `asc xcode build` for an ordinary simulator, device, or CI validation build. Provide exactly one project or workspace and a scheme.
+
+```bash
+asc xcode build \
+  --project "App.xcodeproj" \
+  --scheme "App" \
+  --destination "platform=iOS Simulator,name=iPhone 17 Pro Max,OS=27.0" \
+  --no-code-signing \
+  --result-bundle-path ".asc/artifacts/App.xcresult" \
+  --output json
+```
+
+When `--derived-data-path` is omitted, asc uses a stable cache outside the source checkout. The result-bundle destination must not already exist. Xcode logs go to stderr and the structured result goes to stdout.
+
 ## Preferred iOS/tvOS/visionOS build flow
 
 ### 1. Archive with asc


### PR DESCRIPTION
## Summary

- Add the first-class `asc xcode build` path for ordinary simulator, device, and CI builds.
- Cover TestFlight upload-only mode, build-to-group lookup, and the updated next-build-number selection rule.

## CLI evidence

Validated against release `4.0.0` at `c595cd8db220a83b1bf8298960d2332e2d829ee7`:

- `asc xcode build --help`
- `asc publish testflight --help`
- `asc testflight groups list --help`
- `asc builds next-build-number --help`

## Validation

- Tagged 4.0.0 command-help checks
- `python3 scripts/validate-plugin-packaging.py . --expected-skills 23`
- `python3 -m unittest discover -s tests -p "test_*.py"`
- `agentskills validate` from `skills-ref==0.1.1` for all 23 skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented automatic next-build-number selection, including handling of processed builds, uploads, invalid values, and fallback behavior.
  * Added guidance for inspecting TestFlight groups and uploading IPAs without distribution.
  * Documented compile-without-archiving workflows, including project settings, code signing, result bundles, caching, and output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->