### PR TITLE
docs: document asc 4.0 signing and migration behavior

### DIFF
--- a/skills/asc-metadata-sync/SKILL.md
+++ b/skills/asc-metadata-sync/SKILL.md
@@ -145,6 +145,12 @@ asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir "./fa
 asc migrate import --app "APP_ID" --version-id "VERSION_ID" --fastlane-dir "./fastlane" --confirm
 ```
 
+Deliverfile `metadata_path` and `screenshots_path` values take precedence and resolve relative to the Deliverfile. With `--fastlane-dir "./fastlane"`, use `metadata_path "./metadata"` rather than `"./fastlane/metadata"`; the latter resolves to `./fastlane/fastlane/metadata`. Fix stale values in the Deliverfile, or remove them to use the conventional `metadata/` and `screenshots/` directories.
+
+Paths outside the selected Fastlane directory fail unless the operator explicitly trusts them with `--allow-external-metadata` or `--allow-external-screenshots`. Keep those flags off for untrusted imports.
+
+Inspect the validation body as well as the process exit: `asc migrate validate` can return a report with `valid: false` and a nonzero `errorCount` while exiting 0. A confirmed import can print `status: "partial"` with completed stages and failure details while exiting nonzero, so non-empty stdout does not mean success.
+
 ## Character limits
 
 | Field | Limit |

--- a/skills/asc-signing-setup/SKILL.md
+++ b/skills/asc-signing-setup/SKILL.md
@@ -41,6 +41,8 @@ Use this skill when you need to create or renew signing assets for iOS/macOS app
    - `asc profiles inspect --path "./profiles/AppStore.mobileprovision" --entitlements --output markdown`
    - `asc profiles local install --path "./profiles/AppStore.mobileprovision"`
    - `asc profiles local list --output table`
+   - On macOS, the default directory follows the active Xcode: Xcode 16 or newer uses `~/Library/Developer/Xcode/UserData/Provisioning Profiles`; Xcode 15 or older uses `~/Library/MobileDevice/Provisioning Profiles`. Hosts without a full active Xcode fall back to the legacy directory and print a note to stderr.
+   - Pass `--install-dir` when automation must target a fixed directory.
 
 ## Rotation and cleanup
 - Revoke old certificates:
@@ -53,6 +55,7 @@ Use this skill when you need to create or renew signing assets for iOS/macOS app
 - Clean local Xcode provisioning profiles:
   - `asc profiles local clean --expired --dry-run`
   - `asc profiles local clean --expired --confirm`
+  - Check the resolved directory in the dry-run output before confirming, or pin it with `--install-dir`.
 
 ## Shared team storage with `asc signing sync`
 Use this when you want a lightweight, non-interactive alternative to fastlane match for encrypted git-backed certificate/profile storage.


### PR DESCRIPTION
## Summary

- Document active-Xcode provisioning profile directories and `--install-dir` pinning before local cleanup.
- Record Deliverfile path precedence, external-path trust flags, validation-report handling, and partial import output.

## CLI evidence

Validated against release `4.0.0` at `c595cd8db220a83b1bf8298960d2332e2d829ee7`:

- `asc profiles local list --help`
- `asc migrate import --help`
- `asc migrate validate --help` and the 4.0 command implementation

## Known CLI docs mismatch

The 4.0 migration guide mentions `asc migrate import --metadata-dir` and `--screenshots-dir`, but the released binary rejects both flags. This PR does not copy those invalid examples into the skill.

## Validation

- Tagged 4.0.0 command-help checks
- `python3 scripts/validate-plugin-packaging.py . --expected-skills 23`
- `python3 -m unittest discover -s tests -p "test_*.py"`
- `agentskills validate` from `skills-ref==0.1.1` for all 23 skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified metadata synchronization guidance, including path resolution, external-path trust, and validation status handling.
  * Documented provisioning profile installation locations across Xcode versions and fallback behavior.
  * Added automation guidance for selecting, verifying, and cleaning provisioning profile directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->