### PR TITLE
docs: use nested review submissions list command

### DIFF
--- a/skills/asc-id-resolver/SKILL.md
+++ b/skills/asc-id-resolver/SKILL.md
@@ -63,7 +63,7 @@ Resolve child localization or image IDs from the corresponding version subtree:
 - `asc testflight pre-release list --app "APP_ID" --platform IOS --paginate`
 
 ## Review submission IDs
-- `asc review submissions-list --app "APP_ID" --paginate`
+- `asc review submissions list --app "APP_ID" --paginate`
 
 ## Output tips
 - Output defaults are TTY-aware: table in a terminal and minified JSON in pipes

--- a/skills/asc-release-flow/references/multi-item-submissions.md
+++ b/skills/asc-release-flow/references/multi-item-submissions.md
@@ -28,7 +28,7 @@ Do not create a review submission from the readiness gate. Start this phase only
 Inspect existing submissions before creating one:
 
 ```bash
-asc review submissions-list \
+asc review submissions list \
   --app "APP_ID" \
   --platform IOS \
   --include "items,appStoreVersionForReview" \


### PR DESCRIPTION
## Summary
- use the 4.2.0 nested `asc review submissions list` command in ID resolution and multi-item submission examples
- retain the existing workflow and flags unchanged

## CLI evidence
- CLI release: `4.2.0` (`e7c6863a5ef7375c91d8e2fd7ea7717c1e96ba52`)
- `asc review submissions list --help` reports the published nested command with `--app`, `--platform`, `--paginate`, and `--output`.
- The current source head `df8c5b11` contains only a Wall of Apps data change after 4.2.0; no further CLI surface changes were found.

## Validation
- `python3 scripts/validate-plugin-packaging.py`
- `asc review submissions list --help` using the built 4.2.0 binary
- `git diff --check`

`quick_validate.py` could not run because the host Python lacks the `yaml` module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the review submission lookup command in the relevant guidance.
  * Updated multi-item submission instructions to use the correct command syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->