### PR TITLE
docs: sync skills with asc 4.3.0

### DIFF
--- a/.github/workflows/validate-plugin-packaging.yml
+++ b/.github/workflows/validate-plugin-packaging.yml
@@ -44,10 +44,10 @@ jobs:
             agentskills validate "${skill_dir}"
             skill_count=$((skill_count + 1))
           done
-          test "${skill_count}" -eq 24
+          test "${skill_count}" -eq 25
 
       - name: Validate cross-host manifests
-        run: python scripts/validate-plugin-packaging.py . --expected-skills 24
+        run: python scripts/validate-plugin-packaging.py . --expected-skills 25
 
       - name: Test packaging validator
         run: python -m unittest discover -s tests -p 'test_*.py'
@@ -77,7 +77,7 @@ jobs:
           installed_path="$(jq -er '.installedPath' <<<"${install_json}")"
           test -d "${installed_path}/skills"
           skill_count="$(find "${installed_path}/skills" -mindepth 2 -maxdepth 2 -type f -name SKILL.md | wc -l | tr -d ' ')"
-          test "${skill_count}" -eq 24
+          test "${skill_count}" -eq 25
 
       - name: Validate and load Claude plugin
         shell: bash
@@ -91,7 +91,7 @@ jobs:
           CLAUDE_CONFIG_DIR="${asc_claude_config_dir}" claude plugin install asc@rorkai
           details="$(CLAUDE_CONFIG_DIR="${asc_claude_config_dir}" claude plugin details asc@rorkai)"
           printf '%s\n' "${details}"
-          grep -F "Skills (24)" <<<"${details}"
+          grep -F "Skills (25)" <<<"${details}"
 
       # Codex CLI 0.144.1 has no plugin validation subcommand, so its manifest is
       # checked by the repository validator and loaded from a disposable CI-only

--- a/README.md
+++ b/README.md
@@ -109,12 +109,29 @@ Build, archive, generate export options, export, and manage Xcode version/build 
 - You need to create an IPA or PKG for upload
 - You're setting up CI/CD build pipelines
 - You need to generate or customize ExportOptions.plist
+- You need a modern `release-testing` IPA for registered devices
 - You're troubleshooting encryption compliance issues
 
 **Example:**
 
 ```bash
 Archive and export my macOS app as a PKG I can upload to App Store Connect.
+```
+
+### asc-ad-hoc-distribution
+
+Prepare and publish verified private iOS installs for registered devices with
+the experimental `asc distribute` workflow.
+
+**Use when:**
+- You need to ship a build outside TestFlight to a controlled device list
+- You want a read-only plan before additive signing and storage mutations
+- You need to resume or live-verify a private S3-compatible distribution run
+
+**Example:**
+
+```bash
+Plan a private release-testing install from this Xcode archive, show me the exact effects, and apply only after I approve the plan hash.
 ```
 
 ### asc-shots-pipeline
@@ -156,6 +173,7 @@ Bundle IDs, capabilities, certificates, provisioning profiles, and encrypted sig
 **Use when:**
 - You are onboarding a new app or bundle ID
 - You need to create or rotate signing assets
+- You need to sync a private identity, reconcile ad hoc profiles, or run a command in an isolated signing environment
 
 **Example:**
 

--- a/scripts/validate-plugin-packaging.py
+++ b/scripts/validate-plugin-packaging.py
@@ -59,8 +59,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--expected-skills",
         type=int,
-        default=24,
-        help="Expected number of packaged skills (default: 24)",
+        default=25,
+        help="Expected number of packaged skills (default: 25)",
     )
     return parser.parse_args()
 

--- a/skills/asc-ad-hoc-distribution/SKILL.md
+++ b/skills/asc-ad-hoc-distribution/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: asc-ad-hoc-distribution
+description: Prepare, publish, resume, and verify private iOS release-testing installs with asc distribute. Use when distributing an IPA to registered devices outside TestFlight, reconciling ad hoc profiles, publishing through caller-owned S3-compatible storage, or diagnosing a resumable private distribution run.
+---
+
+# ASC ad hoc distribution
+
+Use the experimental `asc distribute` workflow to turn an existing iOS archive
+into a private, verified install link for registered devices. Use TestFlight or
+the App Store release skills instead when the build should go through Apple-hosted
+distribution.
+
+Confirm the installed contract before acting:
+
+```bash
+asc distribute --help
+asc distribute plan --help
+asc distribute apply --help
+asc distribute resume --help
+asc distribute status --help
+asc distribute verify --help
+```
+
+## Choose the workflow
+
+- Use `plan` -> `apply` -> `resume`/`status` -> `verify` for an end-to-end,
+  hash-authorized run starting from an `.xcarchive`.
+- Use `inspect` -> `prepare` -> `publish` only when the caller already owns the
+  ad hoc IPA and wants to operate the lower-level boundaries separately.
+
+## Guardrails
+
+- Treat the distribution spec, devices file, PKCS#12 identity, password file,
+  run state, and exact install-link artifact as private. Keep them out of Git and
+  require owner-only permissions.
+- Never put S3 credentials or presigned URLs in the distribution spec, command
+  output, logs, issues, or chat. Use `ASC_S3_ACCESS_KEY_ID`,
+  `ASC_S3_SECRET_ACCESS_KEY`, and optional `ASC_S3_SESSION_TOKEN`, or the
+  standard AWS SDK credential chain.
+- `plan` is read-only and may exit successfully with `ready: false`. Inspect the
+  typed blockers and effects before continuing.
+- `apply` can register missing devices, create safe App IDs and successor ad hoc
+  profiles, write local artifacts, and publish immutable objects. Run it only
+  after the user authorizes the exact plan hash and effect inventory.
+- The orchestrated workflow supports private access to an existing
+  S3-compatible bucket. It does not create buckets, change policies, delete old
+  builds, install the app, or launch it.
+- Input drift, an immutable-object conflict, expired signing material, or an
+  expired private link requires a new plan. Do not force the old run forward.
+
+## Preconditions
+
+- An existing iOS `.xcarchive` with one main app target. Embedded apps,
+  extensions, Watch apps, and App Clips make the v1 plan not ready.
+- A local iOS distribution PKCS#12 identity and optional protected password file.
+- A protected strict-v1 devices file. For example:
+
+```json
+{"schemaVersion":1,"devices":[{"name":"Test iPhone","udid":"DEVICE_UDID","platform":"IOS"}]}
+```
+
+- App Store Connect authentication with access to devices, Bundle IDs,
+  certificates, and profiles.
+- An existing S3-compatible bucket and valid credentials.
+
+## 1. Create the private distribution spec
+
+Relative paths resolve from the spec directory. The spec does not interpolate
+environment variables or accept credentials. A representative private config is:
+
+```json
+{
+  "schemaVersion": 1,
+  "devicesFile": "devices.json",
+  "signing": {
+    "identity": {
+      "format": "pkcs12",
+      "path": "../signing/distribution.p12",
+      "passwordFile": "../secrets/distribution-p12-password"
+    },
+    "minimumValidityDays": 7,
+    "maxMutations": 32
+  },
+  "publication": {
+    "endpoint": "https://objects.example.com",
+    "downloadEndpoint": "https://downloads.example.com",
+    "region": "auto",
+    "bucket": "ios-builds",
+    "prefix": "team/app",
+    "addressingStyle": "path",
+    "urlTtl": "24h",
+    "downloadGrace": "1h",
+    "verifyTimeout": "30s"
+  },
+  "metadata": {
+    "title": "App",
+    "channel": "pull-request-42",
+    "sourceRevision": "abc123",
+    "sourceUrl": "https://example.com/team/app/commit/abc123"
+  }
+}
+```
+
+`passwordFile`, `certificateSha256`, `downloadEndpoint`, and every metadata field
+are optional. An omitted password file means the PKCS#12 must use an empty
+password. Protect the config and secret inputs before planning:
+
+```bash
+chmod 600 ".asc/distribution/config.json" ".asc/distribution/devices.json"
+chmod 600 ".asc/signing/distribution.p12" ".asc/secrets/distribution-p12-password"
+```
+
+## 2. Plan without mutation
+
+```bash
+asc distribute plan \
+  --archive-path ".asc/artifacts/App.xcarchive" \
+  --config ".asc/distribution/config.json" \
+  --plan ".asc/distribution/plan.json" \
+  --state-dir ".asc/distribution/runs" \
+  --output json
+```
+
+Inspect `ready`, `planHash`, signing validity, destination, and the complete
+ordered `effects` inventory. Resolve blockers and create a new plan when
+`ready` is false. Do not infer readiness from exit code alone.
+
+## 3. Apply the exact authorized plan
+
+After approval of the exact effects, pass the full 64-character hash:
+
+```bash
+PLAN_HASH="$(jq -er '.planHash' ".asc/distribution/plan.json")"
+asc distribute apply \
+  --plan ".asc/distribution/plan.json" \
+  --confirm "$PLAN_HASH" \
+  --output json
+```
+
+Missing, malformed, or unequal confirmation is rejected before side effects.
+Success means publication and live fetch verification completed; it does not
+mean a device installed or launched the app.
+
+## 4. Inspect, resume, and verify
+
+Use the returned `runId`:
+
+```bash
+asc distribute status --run "RUN_ID" --state-dir ".asc/distribution/runs" --output json
+asc distribute resume --run "RUN_ID" --state-dir ".asc/distribution/runs" --output json
+asc distribute verify --run "RUN_ID" --state-dir ".asc/distribution/runs" --timeout 30s --output json
+```
+
+`status` is local-only and succeeds for `running`, `recoverable`, and `blocked`
+runs; branch on typed fields rather than prose. `resume` revalidates durable
+evidence before retrying and never blindly repeats a remote write. `verify` is
+read-only but performs live fetches. Add `--device "DEVICE_SELECTOR"` only when
+the user asks to observe the matching installed bundle, version, and build on a
+connected device; this observation does not prove IPA byte identity.
+
+The exact private install URL is a bearer credential stored only in the
+owner-private link artifact reported by the completed run. Share it only with
+the intended tester through an approved private channel.
+
+## Lower-level IPA workflow
+
+Use this lane when signing and export are already complete. Pass the exact
+`bundleDir` returned by `prepare` to `publish`:
+
+```bash
+asc distribute inspect --ipa ".asc/artifacts/App.ipa" --output json
+asc distribute prepare --ipa ".asc/artifacts/App.ipa" --channel "pull-request-42" --output json
+asc distribute publish \
+  --bundle-dir ".asc/distribution/com.example.app/1.2-42-IPA_SHA_PREFIX" \
+  --endpoint "https://objects.example.com" \
+  --region "auto" \
+  --bucket "ios-builds" \
+  --prefix "team/app" \
+  --receipt ".asc/publishes/app-1.2-42.json" \
+  --link-path ".asc/publishes/app-1.2-42-link.json" \
+  --output json
+```
+
+`inspect` omits raw device UDIDs unless `--include-devices` is explicitly
+needed. `prepare` never overwrites a bundle and reuses only an exact equivalent.
+Private `publish` is the default and writes exact presigned links only to the
+mode-0600 link artifact. Public publication is a separate explicit lane using
+`--access public --public-base-url`; it assumes anonymous reads are already
+configured and never changes storage policy.

--- a/skills/asc-signing-setup/SKILL.md
+++ b/skills/asc-signing-setup/SKILL.md
@@ -29,6 +29,15 @@ Use this skill when you need to create or renew signing assets for iOS/macOS app
        clear its scoped cache, then log in again with the same binary:
        - `asc web auth logout --apple-id "user@example.com"`
        - `asc web auth login --apple-id "user@example.com"`
+   - For App Groups, the public API can enable `APP_GROUPS` but cannot create or
+     associate App Group resources. Use an Account Holder or Admin web session:
+     - `asc web app-groups list --paginate --output table`
+     - `asc web app-groups create --name "Example Shared" --identifier "group.com.example.app.shared" --confirm`
+     - `asc web app-groups assign --group "GROUP_RESOURCE_ID" --bundle-id "BUNDLE_RESOURCE_ID" --confirm`
+     - Resolve the opaque group ID with `asc web app-groups list` and the opaque
+       Bundle ID resource ID with `asc bundle-ids list`. A changed assignment
+       invalidates provisioning profiles containing that App ID, so regenerate
+       affected profiles before the next signed build.
 3. Create a signing certificate:
    - `asc certificates list --certificate-type IOS_DISTRIBUTION`
    - `asc certificates create --certificate-type IOS_DISTRIBUTION --csr "./cert.csr"`
@@ -69,24 +78,87 @@ Use this skill when you need to create or renew signing assets for iOS/macOS app
 Use this when you want a lightweight, non-interactive alternative to fastlane match for encrypted git-backed certificate/profile storage.
 
 ```bash
-# Push current ASC signing assets into an encrypted git repo
+# Protect secret inputs before use
+chmod 600 "./signing-sync-password" "./distribution.p12" "./distribution-p12-password"
+
+# Push a usable private identity with its matching certificate and profile
 asc signing sync push \
   --bundle-id "com.example.app" \
-  --profile-type IOS_APP_STORE \
+  --profile-type IOS_APP_ADHOC \
   --repo "git@github.com:team/certs.git" \
-  --password "$MATCH_PASSWORD"
+  --password-file "./signing-sync-password" \
+  --identity "./distribution.p12" \
+  --identity-password-file "./distribution-p12-password" \
+  --output json
 
 # Pull and decrypt them into a local directory
 asc signing sync pull \
   --repo "git@github.com:team/certs.git" \
-  --password "$MATCH_PASSWORD" \
-  --output-dir "./signing"
+  --password-file "./signing-sync-password" \
+  --output-dir "./signing" \
+  --output json
 ```
 
 Notes:
-- `--password` falls back to `ASC_MATCH_PASSWORD`.
-- The encrypted repo follows a familiar match-style git layout for certs and profiles.
-- `pull` writes files to disk; keychain import or profile installation is a separate step.
+- App Store Connect never returns a private key. Supply the local PKCS#12 with
+  `--identity`, or use `--private-key` with `--identity-sha256` to select its
+  matching App Store Connect certificate. A multi-identity PKCS#12 also needs
+  `--identity-sha256`.
+- Prefer `--password-file`; `ASC_SIGNING_SYNC_PASSWORD` is the non-file fallback.
+  `--password` and `ASC_MATCH_PASSWORD` are deprecated during 4.x and will be
+  rejected in 5.0.0.
+- Certificate/profile-only sync remains supported but reports
+  `identityPresent: false`; it is not a usable signing identity by itself.
+- `pull` reports private identities in `sensitiveFiles` and writes them mode
+  `0600`. Importing or using the pulled identity remains a separate explicit step.
+- Private identity sync rejects `MAC_APP_DIRECT` and
+  `MAC_CATALYST_APP_DIRECT`; certificate/profile-only sync remains available.
+
+## Reconcile ad hoc devices and profiles
+
+Use the experimental reconcile workflow for deterministic, additive changes
+derived from an Xcode archive and a protected desired-devices file:
+
+```bash
+asc signing reconcile plan \
+  --archive-path ".asc/artifacts/App.xcarchive" \
+  --devices-file ".asc/distribution/devices.json" \
+  --output json
+
+asc signing reconcile apply \
+  --plan ".asc/distribution/signing/plan.json" \
+  --confirm \
+  --output json
+```
+
+Planning performs no mutation and may return `ready: false`. Apply can register
+missing devices, create safe baseline App IDs, and create successor ad hoc
+profiles; it never deletes or patches resources, enables capabilities, or
+creates certificates. Review the plan before `--confirm`. Use the
+`asc-ad-hoc-distribution` skill when these signing effects should be bound into
+an end-to-end distribution plan hash.
+
+## Run one command with an ephemeral identity
+
+On macOS, avoid persistent login-keychain and profile changes by wrapping the
+child command:
+
+```bash
+asc signing run \
+  --identity "./signing/App.p12" \
+  --identity-password-file "./signing/App-password" \
+  --profile "./signing/App.mobileprovision" \
+  --receipt ".asc/distribution/signing-run.json" \
+  -- xcodebuild -exportArchive \
+    -archivePath ".asc/artifacts/App.xcarchive" \
+    -exportPath ".asc/artifacts/release-testing" \
+    -exportOptionsPlist ".asc/ExportOptions.release-testing.plist"
+```
+
+The command runs directly without a shell, preserves the child's exit code,
+uses an isolated temporary keychain, and cleans up its temporary profile. It
+does not print success data, so the child owns stdout. Never pass identity
+passwords inline.
 
 ## Notes
 - Always check `--help` for the exact enum values (certificate types, profile types).

--- a/skills/asc-xcode-build/SKILL.md
+++ b/skills/asc-xcode-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: asc-xcode-build
-description: Build, archive, generate export options, export, upload, and manage Xcode version/build numbers with the current asc xcode helpers before App Store Connect upload or submission. Use when creating an IPA or PKG for upload.
+description: Build, archive, generate export options, export, upload, and manage Xcode version/build numbers with the current asc xcode helpers. Use when creating an IPA or PKG for App Store Connect, TestFlight, or registered-device release testing.
 ---
 
 # Xcode build and export
@@ -92,6 +92,38 @@ asc xcode export-options generate \
 ```
 
 For manual signing, add `--signing-style manual` and optionally `--team-id "TEAM_ID"`. Existing files require `--overwrite`.
+
+For an IPA installable on registered devices, use Xcode's current
+`release-testing` method. The older `ad-hoc` spelling is deprecated by Xcode and
+is not accepted by `asc`:
+
+```bash
+asc xcode export \
+  --archive-path ".asc/artifacts/App.xcarchive" \
+  --ipa-path ".asc/artifacts/App.ipa" \
+  --method release-testing \
+  --signing-style manual \
+  --team-id "TEAM_ID" \
+  --output json
+```
+
+Generate the release-testing plist separately when it needs review or reuse:
+
+```bash
+asc xcode export-options generate \
+  --archive-path ".asc/artifacts/App.xcarchive" \
+  --method release-testing \
+  --signing-style manual \
+  --team-id "TEAM_ID" \
+  --output-path ".asc/ExportOptions.release-testing.plist" \
+  --output json
+```
+
+`release-testing` always exports locally and cannot be combined with `--wait`.
+An explicit `--export-options` plist cannot be combined with `--method`,
+`--signing-style`, or `--team-id`. For device/profile reconciliation, isolated
+signing, private publication, resumability, and live verification, use the
+`asc-ad-hoc-distribution` skill instead of assembling those stages manually.
 
 To upload directly through Xcode and wait for App Store Connect processing, omit `--export-options` and add `--wait`:
 
@@ -192,6 +224,7 @@ macOS requires ICNS icons with all required sizes. Fix the asset catalog, rebuil
 ## Notes
 
 - Prefer `asc xcode archive` and `asc xcode export` for deterministic local artifacts.
+- The default generated export method remains `app-store-connect`; request `--method release-testing` explicitly for registered-device installs.
 - Use `--overwrite` only when replacing existing local artifacts intentionally.
 - Use `--wait` on upload/publish paths when the next step depends on processed builds.
 - For submission readiness, use `asc-submission-health`.


### PR DESCRIPTION
## Summary

- add a focused `asc-ad-hoc-distribution` skill for the new plan/apply/resume/status/verify and inspect/prepare/publish workflows
- document 4.3.0 private identity sync, signing reconciliation, ephemeral signing execution, and Developer Portal App Groups
- document Xcode `release-testing` export and export-options generation
- update cross-host packaging checks from 24 to 25 skills

## Evidence

- ASC CLI release: `4.3.0`
- ASC CLI commit: `7094c18de79b6da89330550e6c2cdf77fe25640c`
- skills base: `e862cb690210948bb997f04e050fea978c8fa6c6`
- built `asc` from the exact release tag and verified every added command path and flag with live `--help`
- reviewed the `4.2.0...4.3.0` source and generated-command delta; no unrelated skill drift was found

## Validation

- all 25 skills: `agentskills validate` with `skills-ref==0.1.1`
- new skill: current skill-creator `quick_validate.py`
- `python3 scripts/validate-plugin-packaging.py . --expected-skills 25`
- `python3 -m unittest discover -s tests -p "test_*.py"`
- JSON and shell syntax checks for added examples
- `git diff --check`

## Live verification

No App Store Connect, Developer Portal, signing, keychain, device, or object-storage mutations were performed. The changes are documentation and packaging metadata only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for private iOS ad hoc distribution to registered devices.
  * Added `release-testing` guidance for creating builds intended for registered-device testing.
  * Expanded signing setup guidance for App Groups, private identities, ad hoc profiles, and isolated signing environments.
* **Documentation**
  * Added detailed workflows for planning, signing, distributing, inspecting, and verifying private builds.
* **Chores**
  * Updated packaging validation to recognize 25 available skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->